### PR TITLE
Fix: accidentaly removed ability say to hivemind through general radio

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -68,3 +68,8 @@
 		show_message("(<a href='byond://?src=[REF(src)];watch_xeno_name=[X.nicknumber]'>F</a>) [X.hivemind_start()] [span_message("hisses, '[message]'")][X.hivemind_end()]", 2)
 	else
 		return ..()
+
+/mob/living/carbon/xenomorph/get_saymode(message, talk_key)
+	if(message[1] == ";")
+		return SSradio.saymodes["a"]
+	return ..()


### PR DESCRIPTION
По неопытности удалил полезную фичу. Вернул на место