### PR TITLE
Tweak: removal of FPS config setting and debug info in autofire SS

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -248,40 +248,14 @@ Master controller and performance related.
 	if(.)
 		Master.UpdateTickRate()
 
-/datum/config_entry/number/fps
-	config_entry_value = 20
-	integer = FALSE
-	min_val = 1
-	max_val = 100   //byond will start crapping out at 50, so this is just ridic
-	var/sync_validate = FALSE
-
-/datum/config_entry/number/fps/ValidateAndSet(str_val)
-	. = ..()
-	if(.)
-		sync_validate = TRUE
-		var/datum/config_entry/number/ticklag/TL = config.entries_by_type[/datum/config_entry/number/ticklag]
-		if(!TL.sync_validate)
-			TL.ValidateAndSet(10 / config_entry_value)
-		sync_validate = FALSE
-
 /datum/config_entry/number/ticklag
 	config_entry_value = 0.5
 	integer = FALSE
 	var/sync_validate = FALSE
 
-/datum/config_entry/number/ticklag/New()	//ticklag weirdly just mirrors fps
-	var/datum/config_entry/CE = /datum/config_entry/number/fps
-	config_entry_value = 10 / initial(CE.config_entry_value)
-	return ..()
 
 /datum/config_entry/number/ticklag/ValidateAndSet(str_val)
 	. = text2num(str_val) > 0 && ..()
-	if(.)
-		sync_validate = TRUE
-		var/datum/config_entry/number/fps/FPS = config.entries_by_type[/datum/config_entry/number/fps]
-		if(!FPS.sync_validate)
-			FPS.ValidateAndSet(10 / config_entry_value)
-		sync_validate = FALSE
 
 /datum/config_entry/number/tick_limit_mc_init	//SSinitialization throttling
 	config_entry_value = TICK_LIMIT_MC_INIT_DEFAULT

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -214,7 +214,6 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
 	// Set world options.
-	world.change_fps( CONFIG_GET(number/fps) )
 	var/initialized_tod = REALTIMEOFDAY
 
 	if(sleep_offline_after_initializations)

--- a/code/controllers/subsystem/autofire.dm
+++ b/code/controllers/subsystem/autofire.dm
@@ -21,10 +21,6 @@ SUBSYSTEM_DEF(automatedfire)
 	wait = 1
 	priority = FIRE_PRIORITY_AUTOFIRE
 
-	var/debug_enabled = FALSE
-	var/DEBUG_next_fire_bigger_world_time = 0
-	var/DEBUG_not_shooting_return = 0
-	var/DEBUG_no_callback_fire_invoke = 0
 	/// world.time of the first entry in the bucket list, effectively the 'start time' of the current buckets
 	var/head_offset = 0
 	/// Index of the first non-empty bucket

--- a/code/datums/components/autofire.dm
+++ b/code/datums/components/autofire.dm
@@ -103,17 +103,11 @@
 ///Ask the shooter to fire and schedule the next shot if need
 /datum/component/automatedfire/autofire/process_shot()
 	if(!shooting)
-		if(SSautomatedfire.debug_enabled)
-			SSautomatedfire.DEBUG_not_shooting_return++
 		return
 	if(next_fire > world.time)//This mean duplication somewhere, we abort now
-		if(SSautomatedfire.debug_enabled)
-			SSautomatedfire.DEBUG_next_fire_bigger_world_time++
 		return
 	if(!callback_fire.Invoke())//If the parent has failed to fire, we reset the component
 		hard_reset()
-		if(SSautomatedfire.debug_enabled)
-			SSautomatedfire.DEBUG_no_callback_fire_invoke++
 		return
 	switch(fire_mode)
 		if(GUN_FIREMODE_BURSTFIRE)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -338,15 +338,6 @@ GLOBAL_VAR(restart_counter)
 	else
 		hub_password = "SORRYNOPASSWORD"
 
-/world/proc/change_fps(new_value = 20)
-	if(new_value <= 0)
-		CRASH("change_fps() called with [new_value] new_value.")
-	if(fps == new_value)
-		return //No change required.
-
-	fps = new_value
-	on_tickrate_change()
-
 
 /world/proc/change_tick_lag(new_value = 0.5)
 	if(new_value <= 0)


### PR DESCRIPTION
ФПС это рудимент, т.к. везде используется tick_lag и оба этих параметра взаимосвязаны.

Дебаг информация в сабсистеме "Automated fire" нам больше не нужна. Причина проблем со стрельбой заключается в погрешностях округления тиклага, отличного от 0.1, 0.25, 0.5, 1 и т.д.