### PR TITLE
Tweak: GC won't do unnecessary hard dels

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -239,7 +239,7 @@ SUBSYSTEM_DEF(garbage)
 	if (isnull(D))
 		return
 	if (level > GC_QUEUE_COUNT)
-		HardDelete(D)
+		HardDelete(D, TRUE)
 		return
 	var/gctime = world.time
 	var/refid = "\ref[D]"
@@ -250,14 +250,18 @@ SUBSYSTEM_DEF(garbage)
 	queue[++queue.len] = list(gctime, refid) // not += for byond reasons
 
 //this is mainly to separate things profile wise.
-/datum/controller/subsystem/garbage/proc/HardDelete(datum/D)
+/datum/controller/subsystem/garbage/proc/HardDelete(datum/D, from_queue = FALSE)
 	++delslasttick
 	++totaldels
 	var/type = D.type
 	var/refID = "\ref[D]"
 
 	var/tick_usage = TICK_USAGE
-	del(D)
+	//if something came from the GC queue we won't harddel it because it takes too much time
+	//but we will log it and fix its destructor in the future (lol do you really belive in it?)
+	//also you may notice that this crutch covers only QDEL_HINT_HARDDEL_NOW hint, but there are no uses of QDEL_HINT_HARDDEL, so let it be like that
+	if(!from_queue)
+		del(D)
 	tick_usage = TICK_USAGE_TO_MS(tick_usage)
 
 	var/datum/qdel_item/I = items[type]

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -217,7 +217,7 @@ SUBSYSTEM_DEF(garbage)
 					#endif
 					continue
 			if (GC_QUEUE_HARDDELETE)
-				HardDelete(D)
+				HardDelete(D, TRUE)
 				if (MC_TICK_CHECK)
 					return
 				continue


### PR DESCRIPTION
Byond's del() takes too much time to find all references and clear them. We can't spend our limited CPU resources on that, but we have about 2.5GB spare memory 😉 
Let this garbage just lie in the memory dump, it will be cleared out on the reboot anyway

(yes I know something may break because of deleted object that stays in a sort of processing list or so on, but who cares?)