### PR TITLE
Tweak: Removing Airlocks To Chemistry

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -5121,7 +5121,7 @@
 "rv" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/purple/side{
-	dir = 4
+	dir = 6
 	},
 /area/mainship/medical/chemistry)
 "rw" = (
@@ -10605,10 +10605,6 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "HS" = (
-/obj/machinery/door/airlock/mainship/medical/free_access{
-	dir = 2;
-	name = "Chemistry"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -10829,7 +10825,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/purple/corner,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
 /area/mainship/medical/chemistry)
 "IB" = (
 /turf/open/floor/mainship/mono,
@@ -11444,12 +11442,9 @@
 	},
 /area/mainship/living/commandbunks)
 "Kw" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
-	dir = 1;
-	name = "Chemistry";
-	req_one_access = list(2,8,40)
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "Kx" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -13174,6 +13169,9 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/engineering/engineering_workshop)
+"PK" = (
+/turf/open/floor/mainship/sterile/purple/corner,
+/area/mainship/medical/chemistry)
 "PL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -22556,7 +22554,7 @@ Gl
 Hd
 HQ
 IA
-Jv
+Jt
 rv
 Jv
 Jv
@@ -22653,8 +22651,8 @@ Fg
 Gm
 kt
 HQ
-HR
-Jt
+PK
+Jv
 Kw
 HQ
 Is

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -483,7 +483,7 @@
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/purple/side{
-	dir = 5
+	dir = 1
 	},
 /area/mainship/medical/chemistry)
 "bD" = (
@@ -573,18 +573,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "bU" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
-	dir = 1;
-	name = "Chemistry";
-	req_one_access = list(2,8,40)
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/chemistry)
 "bV" = (
 /obj/machinery/door_control/mainship/ammo{
@@ -1776,9 +1770,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/engineering/lower_engineering)
 "fy" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-05"
-	},
+/obj/structure/flora/pottedplant,
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
@@ -11063,14 +11055,6 @@
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
-"Hd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
-	},
-/area/mainship/medical/medical_science)
 "He" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -11117,7 +11101,9 @@
 "Hi" = (
 /obj/structure/disposalpipe/segment/corner,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 10
+	},
 /area/mainship/medical/chemistry)
 "Hj" = (
 /obj/structure/disposalpipe/segment,
@@ -15477,7 +15463,7 @@
 /area/mainship/medical/lower_medical)
 "Td" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
+/turf/open/floor/mainship/sterile/purple/corner{
 	dir = 1
 	},
 /area/mainship/medical/chemistry)
@@ -15865,7 +15851,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42444,7 +42429,7 @@ yl
 ZX
 ZX
 gg
-Hd
+Wb
 qs
 ZX
 Rf

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -214,9 +214,7 @@
 /turf/closed/wall/mainship/white,
 /area/sulaco/medbay)
 "aaM" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/shutters/opened/medbay,
+/obj/machinery/smartfridge/chemistry,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/medbay/chemistry)
 "aaN" = (
@@ -285,8 +283,9 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/upperdeck_north_maint)
 "aaX" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/open/floor/plating/platebotc,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
 /area/sulaco/medbay/chemistry)
 "aaY" = (
 /turf/open/floor/prison/sterilewhite,
@@ -16589,9 +16588,6 @@
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_2)
 "kzw" = (
-/obj/machinery/door/airlock/mainship/generic,
-/obj/machinery/door/poddoor/shutters/opened/medbay,
-/obj/machinery/door/firedoor/mainship,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -16599,7 +16595,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -25010,9 +25005,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/sulaco/command/ai)
 "wnS" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-05"
-	},
+/obj/structure/flora/pottedplant,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hydro)
 "woe" = (
@@ -26015,9 +26008,7 @@
 "xMz" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship,
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-05"
-	},
+/obj/structure/flora/pottedplant,
 /turf/open/floor/tile/hydro,
 /area/sulaco/hydro)
 "xMC" = (

--- a/_maps/map_files/Talos/TGS_Talos.dmm
+++ b/_maps/map_files/Talos/TGS_Talos.dmm
@@ -1883,9 +1883,7 @@
 /turf/open/floor/plating,
 /area/mainship/hull/upper_hull)
 "bxo" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-05"
-	},
+/obj/structure/flora/pottedplant,
 /obj/effect/decal/woodsiding,
 /obj/structure/sign/prop1,
 /obj/machinery/light,
@@ -9896,7 +9894,6 @@
 /turf/closed/wall/mainship/gray,
 /area/mainship/shipboard/firing_range)
 "hEV" = (
-/obj/structure/window/framed/mainship/white,
 /obj/machinery/smartfridge/chemistry,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/chemistry)
@@ -10254,14 +10251,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"hUl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window{
-	dir = 8
-	},
-/obj/machinery/door/window/secure,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/chemistry)
 "hUJ" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/silver,
@@ -11779,16 +11768,6 @@
 /obj/structure/ship_ammo/rocket/banshee,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"jhy" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/secure{
-	dir = 2
-	},
-/obj/machinery/door/window/secure{
-	dir = 1
-	},
-/turf/open/floor/prison/whitegreen/full,
-/area/mainship/medical/lounge)
 "jhB" = (
 /obj/structure/table/mainship,
 /obj/item/storage/box/pillbottles,
@@ -19719,10 +19698,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/bow_hallway)
-"oXn" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/open/floor/prison/whitegreen/full,
-/area/mainship/medical/lounge)
 "oXC" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/prison/whitegreen/corner{
@@ -20150,9 +20125,7 @@
 /obj/machinery/landinglight/ds1{
 	dir = 8
 	},
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-05"
-	},
+/obj/structure/flora/pottedplant,
 /obj/effect/ai_node,
 /turf/open/floor/carpet,
 /area/mainship/command/corporateliaison)
@@ -54469,8 +54442,8 @@ gme
 gme
 hgK
 hEV
-hUl
-hmO
+gme
+gme
 uFv
 uFv
 uFv
@@ -55499,7 +55472,7 @@ hHk
 jOU
 ryI
 ikc
-oXn
+eUJ
 eUJ
 ney
 eUJ
@@ -55756,7 +55729,7 @@ ksk
 ksk
 tQf
 bTy
-jhy
+eUJ
 eUJ
 ney
 eUJ

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -4333,6 +4333,9 @@
 /area/mainship/medical/surgery_hallway)
 "boR" = (
 /obj/machinery/bodyscanner,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/corner{
 	dir = 1
 	},
@@ -4931,9 +4934,6 @@
 	dir = 9
 	},
 /area/mainship/medical/lower_medical)
-"buq" = (
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/chemistry)
 "bur" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -5324,7 +5324,6 @@
 /area/mainship/hallways/hangar/droppod)
 "byW" = (
 /obj/machinery/chem_master,
-/obj/machinery/light,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
@@ -9476,6 +9475,9 @@
 "dUJ" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/tool/hand_labeler,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/chemistry)
 "dVK" = (
@@ -11162,14 +11164,8 @@
 	},
 /area/mainship/squads/req)
 "hiF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window{
-	dir = 8
-	},
-/obj/machinery/door/window/secure,
-/obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "hjo" = (
 /obj/machinery/marine_selector/clothes/synth,
 /turf/open/floor/mainship/mono,
@@ -13943,13 +13939,6 @@
 	},
 /area/mainship/hallways/aft_hallway)
 "lZN" = (
-/obj/machinery/door/airlock/multi_tile/mainship/research{
-	dir = 2;
-	name = "Research Chemical Lab"
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/medical_science)
 "may" = (
@@ -14473,6 +14462,9 @@
 "mUE" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/recharger,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -17495,12 +17487,8 @@
 /turf/open/floor/plating,
 /area/mainship/squads/delta)
 "spn" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/smartfridge/chemistry,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/chemistry)
 "spV" = (
 /obj/effect/decal/warning_stripes/nscenter,
 /obj/effect/decal/warning_stripes/thin{
@@ -20542,7 +20530,6 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
-/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -52730,7 +52717,7 @@ wyX
 bJG
 yea
 ost
-nCT
+bxw
 bxw
 bxw
 mUE
@@ -52990,7 +52977,7 @@ sBz
 nSl
 spn
 hiF
-xLb
+spn
 nSl
 nSl
 xLb
@@ -54530,9 +54517,9 @@ tjn
 xCa
 bKC
 nSl
-buq
-buq
-buq
+blP
+blP
+blP
 blP
 kLG
 buD
@@ -57880,10 +57867,10 @@ awF
 sZv
 aAj
 alz
-aEX
+alz
 nZA
 lZN
-aEX
+alz
 alz
 ruj
 bQv


### PR DESCRIPTION
# Список изменений
* Удалены излишние шлюзы, чтобы марины имели человеческий доступ в химию и не ломали корабль.