### PR TITLE
Бафф регена сандера у Горгера во время дрейна

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -141,7 +141,7 @@
 		while((owner_xeno.health < owner_xeno.maxHealth || owner_xeno.overheal < owner_xeno.xeno_caste.overheal_max) &&do_after(owner_xeno, 2 SECONDS, TRUE, target_human, BUSY_ICON_HOSTILE))
 			overheal_gain = owner_xeno.heal_wounds(2.2)
 			adjustOverheal(owner_xeno, overheal_gain)
-			owner_xeno.adjust_sunder(-0.5)
+			owner_xeno.adjust_sunder(-3.5)
 		to_chat(owner_xeno, span_notice("We feel fully restored."))
 		return
 	owner_xeno.face_atom(target_human)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Увеличение регенерации сандера Горгера во время дрейна трупешника в 7 раз.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Изначальные 0.5 восстановления во время дрейна ( +  пассивные для ксено без феро) являются по факту абсолютно бесполезными. 
Количество регенерируемого сандера зависит от времени использования дрейна, а время использования дрейна зависит от количества ХП горджера. Итого, на лоухп после продолжительного дрейна восстанавливается ~10% сандера, что если подсчитать то равняется АЖ  2 защиты от пуль и 4 от бомб на эншенте. 
Учитывая на практике, что горджер  быстро восстанавливает свое хп (но не сандер) и каждый горохострел снижает сандер не меньше чем на 0.5, то выходит, горджер бегает весь раунд без своей и так малой защиты. 
ПР увеличивает восстановление при длительном дрейне на ~35%.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

