### PR TITLE
Твик нейроплевка претора

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2353,22 +2353,23 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/xeno/toxin/heavy //Praetorian
 	name = "neurotoxic splash"
 	added_spit_delay = 0
-	spit_cost = 100
+	spit_cost = 400
 	damage = 40
 	smoke_strength = 0.9
-	reagent_transfer_amount = 8.5
+	reagent_transfer_amount = 18
+	smoke_range = 1
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
 	smoke_strength = 0.9
-	reagent_transfer_amount = 9
+	reagent_transfer_amount = 19
 
 /datum/ammo/xeno/toxin/heavy/upgrade2
 	smoke_strength = 0.95
-	reagent_transfer_amount = 9.5
+	reagent_transfer_amount = 20
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
 	smoke_strength = 1
-	reagent_transfer_amount = 10
+	reagent_transfer_amount = 21
 
 
 /datum/ammo/xeno/sticky


### PR DESCRIPTION
- Стоимость плевка в плазме увеличена с 100 до 400
- Обьем дыма увеличен на 1 тайл(в целом теперь покрывает 5 тайлов вместо 1)
- Вводимый нейротоксин за попадание увеличен с 8.5/9/9.5/10 до 18/19/20/21

