### PR TITLE
Возвращает цену и скорость постройки цветков ХМа

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -228,7 +228,10 @@
 	switch(X.selected_resin)
 		if(/obj/alien/resin/sticky)
 			build_resin_modifier = 0.5
-
+		if(/obj/alien/resin/resin_growth)
+			return 0
+		if(/obj/alien/resin/resin_growth/door)
+			return 0
 	return (base_wait + scaling_wait - max(0, (scaling_wait * X.health / X.maxHealth))) * build_resin_modifier
 
 /datum/action/xeno_action/activable/secrete_resin/proc/build_resin(turf/T)
@@ -325,6 +328,10 @@
 
 	switch(X.selected_resin)
 		if(/obj/alien/resin/sticky)
+			plasma_cost = initial(plasma_cost) / 3
+		if(/obj/alien/resin/resin_growth)
+			plasma_cost = initial(plasma_cost) / 3
+		if(/obj/alien/resin/resin_growth/door)
 			plasma_cost = initial(plasma_cost) / 3
 
 	if(new_resin)


### PR DESCRIPTION
Возвращает мгновенную постройку цветов ХМа и их сниженную цену которые были убраны из-за автоматического разрешения конфликтов


