### PR TITLE
xenoups. rava, queen and hive upgrade.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -181,17 +181,17 @@
 	primordial_message = "Destiny bows to our will as the universe trembles before us."
 	upgrade = XENO_UPGRADE_FOUR
 	// *** Melee Attacks *** //
-	melee_damage = 23
+	melee_damage = 25
 
 	// *** Speed *** //
 	speed = -0.3
 
 	// *** Plasma *** //
-	plasma_max = 1200
+	plasma_max = 1300
 	plasma_gain = 70
 
 	// *** Health *** //
-	max_health = 500
+	max_health = 550
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 65, BULLET = 65, LASER = 65, ENERGY = 65, BOMB = 30, BIO = 60, "rad" = 60, FIRE = 60, ACID = 60)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -148,7 +148,7 @@
 	upgrade = XENO_UPGRADE_FOUR
 
 	// *** Melee Attacks *** //
-	melee_damage = 30
+	melee_damage = 33
 
 	// *** Speed *** //
 	speed = -1

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -123,7 +123,7 @@
 	upgrade = XENO_UPGRADE_THREE
 
 	// *** Melee Attacks *** //
-	melee_damage = 30
+	melee_damage = 33
 
 	// *** Speed *** //
 	speed = -1

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -327,7 +327,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	icon = "smartminions"
 	flags_gamemode = ABILITY_DISTRESS
 	flags_upgrade = UPGRADE_FLAG_ONETIME|UPGRADE_FLAG_MESSAGE_HIVE
-	psypoint_cost = 500
+	psypoint_cost = 200
 
 /datum/hive_upgrade/primordial
 	category = "Xenos"
@@ -343,7 +343,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 /datum/hive_upgrade/primordial/tier_four
 	name = PRIMORDIAL_TIER_FOUR
 	desc = "Unlocks the primordial for the last tier"
-	psypoint_cost = 600
+	psypoint_cost = 50
 	icon = "primoqueen"
 
 /datum/hive_upgrade/primordial/tier_three


### PR DESCRIPTION
Фиксы ксеноишуя.

Равагер по идее должен иметь высокий урон, но что бы его сделать ему нужно влетать в мили  и обычно в толпу маринов. Чутка подниму урон на эйшенте, тогда самые большие когти в игре будут наносить самый большой урон в мили (у кинга например макс урон 30)
•	мили 28/28/30/30 – 28/28/33/33

Проведя аналитические расчеты баланса через нейро сеть группа наших аналитиков пришла к тому, что мамка недостаточно толстая. Квина (по идее) самый сильный ксенос (кинг миф) и вообще роль единственная, ответственная и стрессовая – а недостатки нужно компенсировать
Короче это единственный в своем роде ап статов на примо
•	мили 20/20/23/23 – 20/20/23/23/25
•	хп 425/450/475/500 – 425/450/475/500/550
•	плазма 900/1000/1100/1200 – 900/1000/1100/1200/1300

Самое главное, что примо для Т4 буде халявным. Я хотел вообще убрать необходимость покупки, но кривыми руками в кривой код лучше не лезть, так что минимум вмешательства. Теперь примо Т4 стоит символические 50
•	Цена пси на Т4 примо 600 – 50
Одна из проблем игры на квине была, в том, что тратить только ради себя 600 пси (ну или двух ксенов, если есть шрек) – это херня идея. Всегда выгоднее купить примо другим, купить спавнеры, башни… да что угодно. По итогу лидер мог позволить себе купить примо и использовать его когда уже куплено все остальное и игра уже выиграна. Считаю разумным такое послабление для лидера и будет веселее играть.

Ну ещё умных миньонов дешевле можно сделать, по выше изложенным причинам. Прикольно конечно когда платишь 500, а там никто не заходит… ну тут как с королем рулетка, делаем рулетку дешевле.
•	Цена пси на смарт миньонов 500 – 200 
