### PR TITLE
Revert "Ravager super rage nerf"

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -289,7 +289,7 @@
 	rage_power = (1-(X.health/X.maxHealth)) * RAVAGER_RAGE_POWER_MULTIPLIER //Calculate the power of our rage; scales with difference between current and max HP
 
 	if(X.health < 0) //If we're at less than 0 HP, it's time to max rage.
-		rage_power = 0.5
+		rage_power = 1
 
 	var/rage_power_radius = CEILING(rage_power * 7, 1) //Define radius of the SFX
 
@@ -308,7 +308,7 @@
 		var/datum/action/xeno_action/endure/endure_ability = X.actions_by_path[/datum/action/xeno_action/endure]
 
 		if(endure_ability.endure_duration) //Check if Endure is active
-			endure_ability.endure_threshold = RAVAGER_ENDURE_HP_LIMIT * (1 + rage_power) //Endure crit threshold scales with Rage Power; min -100, max -150
+			endure_ability.endure_threshold = RAVAGER_ENDURE_HP_LIMIT * (1 + rage_power) //Endure crit threshold scales with Rage Power; min -100, max -200
 
 		if(charge)
 			charge.clear_cooldown() //Reset charge cooldown
@@ -326,7 +326,7 @@
 		shake_camera(L, 1 SECONDS, 1)
 		L.Shake(4, 4, 1 SECONDS) //SFX
 
-		if(rage_power >= RAVAGER_RAGE_SUPER_RAGE_THRESHOLD) //If we're super pissed it's time to get crazy
+		if(rage_power > RAVAGER_RAGE_SUPER_RAGE_THRESHOLD) //If we're super pissed it's time to get crazy
 
 			var/obj/screen/plane_master/floor/OT = L.hud_used.plane_masters["[FLOOR_PLANE]"]
 			var/obj/screen/plane_master/game_world/GW = L.hud_used.plane_masters["[GAME_PLANE]"]
@@ -344,7 +344,7 @@
 	X.plasma_stored += rage_plasma //Regain a % of our maximum plasma scaling with rage
 
 	rage_sunder = min(X.sunder, rage_power * 100) //Set our temporary Sunder recovery
-	X.adjust_sunder(-1 * rage_sunder) //Restores up to 50 Sunder temporarily.
+	X.adjust_sunder(-1 * rage_sunder) //Restores up to 100 Sunder temporarily.
 
 	X.xeno_melee_damage_modifier += rage_power  //Set rage melee damage bonus
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Возвращает "супер ярость" Опустошителя в изначальное состояние. Откатывает силу ярости с 0.5 в 1.0. Вампиризм снова становиться 60 за удар, возвращен бонус  Endure HP (было -150, стало 200).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->




<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

balance: Увеличивает бонус к супер ярости вдвое: Больше урона, вампиризма, скорости, восстановления сандера
 и дополнительного здоровья (+50)


/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
