### PR TITLE
Railgun rebalance

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -343,6 +343,7 @@
 		/obj/item/ammo_magazine/revolver,
 		/obj/item/ammo_magazine/sniper,
 		/obj/item/ammo_magazine/handful,
+		/obj/item/ammo_magazine/railgun,
 		/obj/item/explosive/grenade,
 		/obj/item/explosive/mine,
 		/obj/item/reagent_containers/food/snacks,

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -841,7 +841,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
 	reciever_flags = AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_AUTO_EJECT|AMMO_RECIEVER_CYCLE_ONLY_BEFORE_FIRE
 
-	fire_delay = 1 SECONDS
+	fire_delay = 3.5 SECONDS
 	burst_amount = 1
 	accuracy_mult = 2
 	recoil = 0

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -306,7 +306,7 @@
 	caliber = CALIBER_RAILGUN
 	icon_state = "railgun"
 	default_ammo = /datum/ammo/bullet/railgun
-	max_rounds = 1
+	max_rounds = 3
 	reload_delay = 20 //Hard to reload.
 	w_class = WEIGHT_CLASS_NORMAL
 	icon_state_mini = "mag_railgun"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -291,17 +291,17 @@ WEAPONS
 /datum/supply_packs/weapons/railgun_ammo
 	name = "Railgun armor piercing discarding sabot round"
 	contains = list(/obj/item/ammo_magazine/railgun)
-	cost = 2
+	cost = 5
 
 /datum/supply_packs/weapons/railgun_ammo/hvap
 	name = "Railgun high velocity armor piercing round"
 	contains = list(/obj/item/ammo_magazine/railgun/hvap)
-	cost = 2
+	cost = 5
 
 /datum/supply_packs/weapons/railgun_ammo/smart
 	name = "Railgun smart armor piercing round"
 	contains = list(/obj/item/ammo_magazine/railgun/smart)
-	cost = 2
+	cost = 5
 
 /datum/supply_packs/weapons/tx8
 	name = "BR-8 Scout Rifle"


### PR DESCRIPTION
Дал обоймам рейлгана 3 патрона в обойме, возможность носить обоймы в разгрузке, повысил цену на все патроны в карго с 2 очков на 5. 
Дал рейлгану задержку между выстрелами в 3.5 секунды.