### PR TITLE
Barrenquilla 1.2: Return of Cringe

### DIFF
--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -781,7 +781,7 @@
 /area/bigredv2/outside/n)
 "ea" = (
 /obj/structure/rack,
-/obj/effect/spawner/random/gun/sidearms,
+/obj/effect/landmark/weapon_spawn/tier1_weapon_spawn,
 /turf/open/floor/tile/red/full,
 /area/barren/security)
 "eb" = (
@@ -1699,6 +1699,10 @@
 /area/barren/civilian)
 "io" = (
 /obj/item/frame/camera,
+/obj/machinery/door_control/unmeltable{
+	id = "secure_blast5";
+	name = "Vault Access"
+	},
 /turf/open/lavaland/basalt{
 	baseturfs = /turf/open/lavaland/basalt
 	},
@@ -2073,12 +2077,8 @@
 /obj/machinery/door/poddoor/mainship/indestructible{
 	dir = 2;
 	id = "secure_blast5";
-	name = "\improper Ash Shelter"
-	},
-/obj/machinery/door_control/unmeltable{
-	id = "secure_blast5";
-	name = "Vault Access";
-	pixel_x = -32
+	name = "\improper Ash Shelter";
+	desc = "That loosks like it doesn't open easily."
 	},
 /turf/open/floor/plating/asteroidfloor,
 /area/bigredv2/outside/w)
@@ -4247,7 +4247,7 @@
 /obj/item/storage/box/flashbangs,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/random/gun,
+/obj/effect/landmark/weapon_spawn/tier2_weapon_spawn,
 /turf/open/floor/tile/red/full,
 /area/barren/security)
 "vK" = (
@@ -6563,7 +6563,7 @@
 /obj/item/clothing/suit/armor/vest,
 /obj/item/clothing/suit/armor/vest,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/ammo,
+/obj/effect/spawner/random/gun,
 /turf/open/floor/tile/red/full,
 /area/barren/security)
 "Id" = (

--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -1,7 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/ne)
 "ad" = (
 /turf/closed/mineral/smooth/indestructible,
@@ -18,7 +20,9 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 1
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/ne)
 "ah" = (
 /turf/closed/mineral/smooth/indestructible,
@@ -164,7 +168,9 @@
 /area/barren/civilian/cook)
 "aV" = (
 /obj/item/lightstick/red/anchored,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/se)
 "aW" = (
 /obj/machinery/light_construct{
@@ -180,7 +186,9 @@
 	dir = 8
 	},
 /obj/structure/closet/walllocker/hydrant/extinguisher,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "ba" = (
 /obj/effect/decal/cleanable/dirt,
@@ -210,7 +218,9 @@
 /area/shuttle/drop1/lz1)
 "bj" = (
 /obj/effect/landmark/weed_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "bl" = (
 /obj/effect/decal/cleanable/cobweb2,
@@ -310,7 +320,9 @@
 /area/barren/engie/engine)
 "bL" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "bM" = (
 /obj/structure/cable,
@@ -342,7 +354,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 8
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "bZ" = (
 /obj/machinery/light{
@@ -353,11 +367,15 @@
 /area/barren/misc/genstorage)
 "ca" = (
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "cb" = (
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "cd" = (
 /obj/structure/disposalpipe/trunk{
@@ -373,7 +391,9 @@
 /area/barren/medical)
 "cg" = (
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "ch" = (
 /obj/effect/ai_node,
@@ -408,7 +428,9 @@
 /area/barren/misc/eastarmory)
 "cs" = (
 /obj/item/trash/cigbutt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "ct" = (
 /obj/effect/decal/remains/human,
@@ -424,7 +446,9 @@
 /obj/structure/barricade/guardrail{
 	dir = 1
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "cx" = (
 /obj/structure/girder/reinforced,
@@ -474,7 +498,9 @@
 "cO" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "cP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -509,7 +535,9 @@
 "cY" = (
 /obj/effect/spawner/random/toolbox,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "cZ" = (
 /obj/structure/barricade/guardrail,
@@ -517,11 +545,15 @@
 	dir = 4;
 	pixel_y = 7
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "da" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "db" = (
 /obj/machinery/light{
@@ -550,7 +582,9 @@
 /area/barren/medical/chemistry)
 "dh" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "dj" = (
 /obj/machinery/power/apc,
@@ -582,7 +616,9 @@
 /area/barren/engie/engine)
 "dt" = (
 /obj/item/tool/pickaxe,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "dw" = (
 /obj/structure/noticeboard,
@@ -591,11 +627,15 @@
 "dx" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "dy" = (
 /obj/item/ore/silver,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "dB" = (
 /obj/structure/table/reinforced/prison,
@@ -623,12 +663,16 @@
 /area/barren/medical)
 "dF" = (
 /obj/structure/ore_box,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "dG" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "dH" = (
 /obj/structure/window/framed/colony,
@@ -686,11 +730,15 @@
 /area/barren)
 "dU" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "dV" = (
 /obj/item/ore/silver,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "dX" = (
 /obj/effect/decal/cleanable/blood/writing,
@@ -749,7 +797,9 @@
 /area/barren/cave/lz1)
 "eo" = (
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "ep" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -766,7 +816,9 @@
 /area/barren/medical/chemistry)
 "er" = (
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/ne)
 "eu" = (
 /turf/open/lavaland/lava/lpiece{
@@ -785,7 +837,9 @@
 	dir = 4;
 	pixel_y = 7
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "ex" = (
 /obj/structure/cable,
@@ -818,7 +872,9 @@
 /area/barren)
 "eB" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "eC" = (
 /obj/structure/window/framed/colony,
@@ -850,7 +906,9 @@
 /area/barren/cave/lz2)
 "eH" = (
 /obj/structure/ore_box,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "eI" = (
 /obj/structure/largecrate/random/case/small,
@@ -858,7 +916,9 @@
 /area/barren/cave/lz1)
 "eK" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "eL" = (
 /obj/structure/barricade/guardrail,
@@ -907,7 +967,9 @@
 /area/barren/misc/refinery)
 "eT" = (
 /obj/item/ore/iron,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "eU" = (
 /obj/effect/decal/remains/human,
@@ -951,7 +1013,9 @@
 /area/barren/civilian)
 "fi" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "fl" = (
 /obj/machinery/smartfridge/chemistry,
@@ -975,7 +1039,9 @@
 /area/barren/security)
 "ft" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "fu" = (
 /obj/effect/decal/cleanable/blood/writing,
@@ -992,7 +1058,9 @@
 /area/barren/engie/engine)
 "fx" = (
 /obj/structure/ore_box,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "fy" = (
 /obj/structure/lattice,
@@ -1031,7 +1099,9 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/hardhat/orange,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "fK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -1041,6 +1111,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
+"fM" = (
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/nw)
 "fN" = (
 /obj/structure/largecrate/supply/supplies,
 /turf/open/floor/marking/delivery,
@@ -1103,7 +1178,9 @@
 "fZ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "gb" = (
 /obj/structure/window/framed/colony,
@@ -1136,7 +1213,9 @@
 /area/barren/cave/lz1)
 "gg" = (
 /obj/effect/landmark/xeno_silo_spawn,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "gh" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -1176,14 +1255,18 @@
 /area/barren/civilian)
 "gp" = (
 /obj/item/clothing/head/hardhat/orange,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "gq" = (
 /obj/structure/bookcase/manuals/engineering,
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
 "gs" = (
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "gt" = (
 /obj/structure/cable,
@@ -1199,11 +1282,15 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 10
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "gy" = (
 /obj/machinery/miner/damaged,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "gz" = (
 /obj/structure/table/mainship,
@@ -1214,7 +1301,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 5
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "gB" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -1328,7 +1417,9 @@
 /area/bigredv2/outside/w)
 "hc" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "hg" = (
 /obj/structure/bed/chair/sofa/right,
@@ -1423,7 +1514,9 @@
 /area/barren/engie/engine)
 "hC" = (
 /obj/machinery/miner/damaged/platinum,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "hD" = (
 /obj/structure/cable,
@@ -1433,7 +1526,9 @@
 /area/bigredv2/outside/w)
 "hE" = (
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/ne)
 "hH" = (
 /turf/open/floor/grimy,
@@ -1453,7 +1548,9 @@
 /area/barren/misc/genstorage)
 "hN" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "hO" = (
 /obj/machinery/light{
@@ -1483,7 +1580,9 @@
 	dir = 8
 	},
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "ib" = (
 /obj/structure/table,
@@ -1505,7 +1604,9 @@
 /area/bigredv2/outside/w)
 "ij" = (
 /obj/item/organ/xenos/hivenode,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "ik" = (
 /turf/open/floor/carpet{
@@ -1528,7 +1629,9 @@
 /area/barren/civilian)
 "io" = (
 /obj/item/frame/camera,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "ip" = (
 /obj/structure/bed/chair/wood/wings{
@@ -1548,7 +1651,9 @@
 "it" = (
 /obj/structure/fence,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "iu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1584,7 +1689,9 @@
 /area/barren/civilian)
 "iC" = (
 /obj/effect/landmark/start/job/xenomorph,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "iD" = (
 /obj/structure/table/reinforced,
@@ -1622,16 +1729,22 @@
 /area/barren/cave/lz2)
 "iL" = (
 /obj/machinery/miner/damaged,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "iM" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "iN" = (
 /obj/structure/powerloader_wreckage,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "iO" = (
 /obj/structure/cable,
@@ -1658,7 +1771,9 @@
 "iT" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "iU" = (
 /obj/effect/landmark/corpsespawner/pmc,
@@ -1737,19 +1852,25 @@
 /area/bigredv2/outside/c)
 "jx" = (
 /obj/structure/barricade/metal,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "jy" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "jA" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 8
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "jB" = (
 /obj/effect/decal/warning_stripes/thick{
@@ -1774,14 +1895,18 @@
 /area/bigredv2/outside/c)
 "jG" = (
 /obj/item/clothing/head/warning_cone,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "jH" = (
 /turf/closed/wall,
 /area/barren/medical)
 "jI" = (
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "jJ" = (
 /obj/effect/landmark/patrol_point{
@@ -1796,7 +1921,9 @@
 /area/barren/medical/research)
 "jN" = (
 /obj/item/assembly/mousetrap/armed,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "jO" = (
 /obj/machinery/vending/coffee,
@@ -1804,7 +1931,9 @@
 /area/barren/cave/lz1)
 "jP" = (
 /obj/item/tool/pickaxe,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "jQ" = (
 /turf/open/floor/tile/red/redtaupecorner{
@@ -1814,7 +1943,9 @@
 "jR" = (
 /obj/structure/fence,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "jS" = (
 /obj/structure/window/framed/colony,
@@ -1836,7 +1967,9 @@
 "kb" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "kc" = (
 /obj/structure/window/reinforced{
@@ -1920,7 +2053,9 @@
 /obj/item/stack/sheet/wood{
 	amount = 50
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "kx" = (
 /obj/structure/cable,
@@ -1950,7 +2085,9 @@
 /area/bigredv2/outside/c)
 "kH" = (
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/se)
 "kK" = (
 /obj/structure/table,
@@ -1980,13 +2117,17 @@
 /area/bigredv2/outside/c)
 "kR" = (
 /obj/machinery/miner/damaged,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "kS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/barren/cave/west)
 "kT" = (
 /obj/structure/barricade/guardrail{
@@ -2017,7 +2158,9 @@
 	id = "TGMC_13";
 	name = "TGMC exit point 13"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "lh" = (
 /obj/effect/decal/woodsiding{
@@ -2069,7 +2212,9 @@
 /area/barren/security)
 "lz" = (
 /obj/structure/lattice,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "lF" = (
 /obj/effect/decal/cleanable/blood/writing,
@@ -2190,7 +2335,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "ml" = (
 /obj/structure/bed/alien,
@@ -2209,7 +2356,9 @@
 /area/ai_monitored/storage/secure)
 "mq" = (
 /obj/item/tool/crowbar,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "mr" = (
 /obj/machinery/landinglight/ds2/delaythree{
@@ -2352,7 +2501,9 @@
 /area/barren/civilian/workdorm)
 "ne" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "ng" = (
 /obj/machinery/vending/hydronutrients,
@@ -2378,7 +2529,9 @@
 /area/barren/civilian/cook)
 "nm" = (
 /obj/item/tool/pickaxe,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "nn" = (
 /obj/machinery/vending/cola,
@@ -2405,7 +2558,9 @@
 /area/barren/misc/eastarmory)
 "nu" = (
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "nw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2438,7 +2593,9 @@
 /obj/structure/barricade/guardrail{
 	dir = 8
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "nE" = (
 /obj/structure/window/framed/colony,
@@ -2459,7 +2616,9 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 8
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "nK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -2492,7 +2651,9 @@
 "nT" = (
 /obj/structure/cable,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "nU" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -2517,7 +2678,9 @@
 /area/barren/security)
 "og" = (
 /obj/item/shard,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "oh" = (
 /obj/structure/closet/secure_closet/medical_doctor,
@@ -2548,7 +2711,9 @@
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/hardhat/orange,
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "op" = (
 /obj/structure/table/reinforced/prison,
@@ -2591,7 +2756,9 @@
 /area/barren/cave/lz2)
 "oC" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "oD" = (
 /obj/machinery/vending/cigarette/colony,
@@ -2615,7 +2782,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 10
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "oK" = (
 /obj/effect/decal/cleanable/blood/writing{
@@ -2666,7 +2835,9 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 4
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "oU" = (
 /obj/structure/filingcabinet,
@@ -2714,7 +2885,9 @@
 /area/barren/cave/lz2)
 "ph" = (
 /obj/machinery/miner/damaged/platinum,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "pj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2740,7 +2913,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/ne)
 "pq" = (
 /turf/open/floor/plating,
@@ -2782,7 +2957,9 @@
 /area/barren/civilian/cook)
 "pF" = (
 /obj/structure/lattice,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "pG" = (
 /obj/structure/table/reinforced,
@@ -2809,7 +2986,9 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 8
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/barren/cave/lz2)
 "pR" = (
 /obj/structure/barricade/guardrail{
@@ -2832,11 +3011,15 @@
 /area/barren/civilian)
 "pW" = (
 /obj/effect/decal/cleanable/blood/writing,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "pX" = (
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "pY" = (
 /obj/effect/decal/cleanable/blood/oil,
@@ -2870,7 +3053,9 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/barren/cave/lz2)
 "ql" = (
 /obj/structure/cable,
@@ -2884,7 +3069,9 @@
 /area/prison/laundry)
 "qn" = (
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "qp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2909,7 +3096,9 @@
 /area/barren/medical)
 "qx" = (
 /obj/structure/barricade/guardrail,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "qy" = (
 /obj/machinery/light{
@@ -2988,7 +3177,9 @@
 "qV" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "qW" = (
 /turf/open/floor/freezer,
@@ -3011,7 +3202,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 5
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "rb" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -3044,7 +3237,9 @@
 "rj" = (
 /obj/item/tool/pickaxe,
 /obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "rm" = (
 /obj/structure/closet/secure_closet/medical1/colony,
@@ -3076,7 +3271,9 @@
 /area/barren)
 "rs" = (
 /obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "rt" = (
 /obj/structure/rack,
@@ -3156,7 +3353,9 @@
 "rM" = (
 /obj/structure/fence,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "rQ" = (
 /obj/effect/ai_node,
@@ -3269,7 +3468,9 @@
 /area/barren/security)
 "sw" = (
 /obj/effect/spawner/random/toolbox,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/se)
 "sy" = (
 /obj/structure/cable,
@@ -3300,11 +3501,15 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "sL" = (
 /obj/item/ore/iron,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "sM" = (
 /obj/effect/decal/cleanable/ash,
@@ -3474,12 +3679,16 @@
 /area/barren/misc/genstorage)
 "tB" = (
 /obj/effect/decal/remains/human,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "tD" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/landmark/weed_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "tE" = (
 /obj/effect/spawner/random/toolbox,
@@ -3492,11 +3701,15 @@
 "tF" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "tG" = (
 /obj/effect/decal/cleanable/blood/writing,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "tI" = (
 /obj/structure/table/mainship,
@@ -3561,11 +3774,15 @@
 "ua" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "ub" = (
 /obj/item/tool/pickaxe,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "uc" = (
 /obj/structure/cable,
@@ -3588,11 +3805,15 @@
 /area/barren/security)
 "uf" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "uh" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "ul" = (
 /obj/structure/bed,
@@ -3665,7 +3886,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/remains/human,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "uF" = (
 /obj/effect/decal/cleanable/blood,
@@ -3730,7 +3953,9 @@
 /area/barren/medical)
 "ve" = (
 /obj/structure/lattice,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "vf" = (
 /obj/item/trash/chips,
@@ -3797,12 +4022,16 @@
 /area/barren)
 "vw" = (
 /obj/effect/landmark/xeno_silo_spawn,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "vy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "vA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3812,7 +4041,9 @@
 "vC" = (
 /obj/effect/landmark/corpsespawner/miner,
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "vE" = (
 /obj/effect/ai_node,
@@ -3898,7 +4129,9 @@
 /area/bigredv2/outside/general_offices)
 "wb" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/se)
 "wc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3923,7 +4156,9 @@
 /turf/open/floor/tile/blue/whitebluefull,
 /area/barren/medical)
 "wj" = (
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/se)
 "wk" = (
 /obj/structure/rack,
@@ -3957,7 +4192,9 @@
 "wq" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "wy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4145,13 +4382,17 @@
 "xG" = (
 /obj/item/lightstick/red/anchored,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "xI" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/hardhat/orange,
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "xK" = (
 /obj/effect/landmark/excavation_site_spawner,
@@ -4163,7 +4404,9 @@
 /area/barren/misc/eastarmory)
 "xN" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/core,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "xO" = (
 /obj/effect/decal/cleanable/blood/oil,
@@ -4181,7 +4424,9 @@
 /area/barren)
 "xU" = (
 /obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/ne)
 "xV" = (
 /obj/machinery/door/airlock/mainship/secure/free_access{
@@ -4199,7 +4444,9 @@
 /area/barren/misc/genstorage)
 "xX" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "xY" = (
 /obj/machinery/mineral/processing_unit,
@@ -4246,7 +4493,9 @@
 /area/barren/security)
 "ym" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "yo" = (
 /obj/structure/cable,
@@ -4294,7 +4543,9 @@
 "yE" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "yH" = (
 /turf/closed/wall/r_wall,
@@ -4384,7 +4635,9 @@
 "zm" = (
 /obj/structure/lattice,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "zn" = (
 /obj/item/clothing/head/warning_cone,
@@ -4406,12 +4659,16 @@
 "zr" = (
 /obj/item/tool/pickaxe,
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "zs" = (
 /obj/item/lightstick/red/anchored,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "zw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4485,7 +4742,9 @@
 /area/barren/civilian/cook)
 "zQ" = (
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "zT" = (
 /obj/structure/flora/pottedplant,
@@ -4496,7 +4755,9 @@
 /area/barren/cave/lz1)
 "zY" = (
 /obj/structure/ore_box,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Aa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4505,7 +4766,9 @@
 "Ab" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /obj/effect/landmark/start/job/xenomorph,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "Ac" = (
 /obj/structure/table/reinforced,
@@ -4531,7 +4794,9 @@
 "Ak" = (
 /obj/structure/cable,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "Al" = (
 /turf/closed/wall,
@@ -4584,11 +4849,15 @@
 /area/barren/cave/lz1)
 "Az" = (
 /obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "AB" = (
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "AC" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -4599,7 +4868,9 @@
 /area/barren/engie/engine)
 "AE" = (
 /obj/item/tool/pickaxe,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "AF" = (
 /obj/structure/table/mainship,
@@ -4659,7 +4930,9 @@
 	id = "SOM_23";
 	name = "SOM exit point 23"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "AV" = (
 /obj/machinery/washing_machine,
@@ -4677,14 +4950,18 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 6
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "AZ" = (
 /obj/effect/landmark/patrol_point{
 	id = "SOM_21";
 	name = "SOM exit point 21"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Ba" = (
 /obj/effect/decal/siding{
@@ -4703,7 +4980,9 @@
 	id = "TGMC_21";
 	name = "TGMC exit point 21"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "Bf" = (
 /turf/open/floor/plating,
@@ -4732,7 +5011,9 @@
 "Bo" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "Bq" = (
 /obj/structure/table,
@@ -4759,7 +5040,9 @@
 /area/bigredv2/outside/c)
 "Bz" = (
 /obj/effect/landmark/weed_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "BA" = (
 /obj/structure/sign/chemistry2,
@@ -4792,7 +5075,9 @@
 "BF" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "BH" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
@@ -4807,11 +5092,15 @@
 "BK" = (
 /obj/machinery/miner/damaged,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "BL" = (
 /obj/effect/decal/cleanable/blood/writing,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "BM" = (
 /obj/structure/closet/secure_closet/security,
@@ -4820,7 +5109,9 @@
 /area/barren/security)
 "BN" = (
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "BO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4837,19 +5128,25 @@
 /area/bigredv2/outside/general_offices)
 "BS" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "BT" = (
 /obj/item/clothing/head/warning_cone,
 /obj/structure/lattice,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "BU" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 9
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "BW" = (
 /obj/structure/bed/chair/wood/wings,
@@ -4857,7 +5154,9 @@
 /area/barren/civilian/workdorm)
 "BX" = (
 /obj/machinery/miner/damaged,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "BZ" = (
 /obj/machinery/light{
@@ -4898,7 +5197,9 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 4
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "Ci" = (
 /obj/effect/decal/siding{
@@ -4910,11 +5211,15 @@
 "Cj" = (
 /obj/item/tool/pickaxe,
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Cl" = (
 /obj/item/organ/xenos/eggsac,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "Cn" = (
 /obj/machinery/door/airlock/freezer,
@@ -4928,7 +5233,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Cq" = (
 /obj/machinery/floodlight/outpost,
@@ -4959,7 +5266,9 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "CB" = (
 /obj/item/trash/hotdog,
@@ -4978,7 +5287,9 @@
 	id = "SOM_24";
 	name = "SOM exit point 24"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "CF" = (
 /obj/structure/cable,
@@ -5034,11 +5345,15 @@
 /area/barren/security)
 "CY" = (
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "Da" = (
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/ne)
 "Db" = (
 /obj/structure/closet,
@@ -5090,7 +5405,9 @@
 /area/barren/civilian/botany)
 "Dq" = (
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Dr" = (
 /obj/structure/bed/chair/wood/normal{
@@ -5179,7 +5496,9 @@
 /area/barren/medical)
 "DW" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/ne)
 "DY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5187,7 +5506,9 @@
 /area/bigredv2/outside/general_offices)
 "DZ" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Ea" = (
 /obj/structure/table/reinforced,
@@ -5231,7 +5552,9 @@
 	id = "TGMC_24";
 	name = "TGMC exit point 24"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "En" = (
 /obj/structure/bed/chair/wood/normal{
@@ -5267,14 +5590,18 @@
 /area/barren/medical)
 "Et" = (
 /obj/effect/decal/remains/xeno,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "Ev" = (
 /obj/effect/landmark/patrol_point{
 	id = "TGMC_23";
 	name = "TGMC exit point 23"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "Ew" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5332,7 +5659,9 @@
 	id = "TGMC_14";
 	name = "TGMC exit point 14"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "EM" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -5362,7 +5691,9 @@
 /area/barren/civilian)
 "EV" = (
 /obj/item/trash/cigbutt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "EW" = (
 /obj/structure/table/reinforced,
@@ -5447,7 +5778,9 @@
 /area/ai_monitored/storage/secure)
 "Fs" = (
 /obj/item/ore/iron,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "Ft" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5636,7 +5969,9 @@
 /area/barren/medical)
 "Go" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/ne)
 "Gp" = (
 /obj/structure/barricade/guardrail{
@@ -5647,7 +5982,9 @@
 "Gq" = (
 /obj/structure/fence,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "Gr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5680,21 +6017,29 @@
 /area/barren/civilian/workdorm)
 "Gy" = (
 /obj/effect/decal/cleanable/ash,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Gz" = (
 /obj/item/lightstick/red/anchored,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "GD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "GE" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 9
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "GH" = (
 /obj/structure/cable,
@@ -5735,7 +6080,9 @@
 "GU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/hardhat/orange,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "GW" = (
 /turf/closed/wall,
@@ -5776,7 +6123,9 @@
 "Hj" = (
 /obj/structure/lattice,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Hk" = (
 /obj/structure/window_frame/colony/reinforced,
@@ -5796,7 +6145,9 @@
 /area/bigredv2/outside/c)
 "Hn" = (
 /obj/structure/girder,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Ho" = (
 /obj/structure/table/mainship,
@@ -5840,7 +6191,9 @@
 "HA" = (
 /obj/structure/barricade/metal,
 /obj/structure/lattice,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "HB" = (
 /turf/closed/mineral/smooth/indestructible,
@@ -5849,7 +6202,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 6
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "HG" = (
 /turf/open/floor/tile/red/redtaupe,
@@ -5861,7 +6216,9 @@
 "HK" = (
 /obj/structure/cable,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "HL" = (
 /obj/effect/decal/woodsiding{
@@ -5880,7 +6237,9 @@
 /area/bigredv2/caves/south)
 "HO" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "HP" = (
 /obj/structure/bed/chair/office/light,
@@ -5975,7 +6334,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "Iu" = (
 /obj/structure/table/reinforced/prison,
@@ -6020,7 +6381,9 @@
 "IE" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "IG" = (
 /obj/structure/closet/crate/radiation,
@@ -6082,7 +6445,9 @@
 /area/barren/civilian/workdorm)
 "Ja" = (
 /obj/item/ore/phoron,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Jb" = (
 /obj/structure/table/mainship,
@@ -6098,7 +6463,9 @@
 "Jd" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Je" = (
 /obj/structure/table/reinforced/prison,
@@ -6141,7 +6508,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 1
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "Jr" = (
 /obj/structure/mirror,
@@ -6156,16 +6525,22 @@
 /area/barren/cave/lz2)
 "Jv" = (
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Jw" = (
 /obj/item/ore/iron,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Jx" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/landmark/weed_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Jy" = (
 /obj/structure/barricade/guardrail{
@@ -6179,7 +6554,9 @@
 /area/barren/civilian)
 "Jz" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "JB" = (
 /obj/structure/closet/cabinet,
@@ -6233,7 +6610,9 @@
 	id = "SOM_22";
 	name = "SOM exit point 22"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "JI" = (
 /obj/structure/bookcase/manuals/research_and_development,
@@ -6244,7 +6623,9 @@
 /area/barren/misc/refinery)
 "JM" = (
 /obj/machinery/miner/damaged,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "JO" = (
 /turf/open/floor/plating,
@@ -6288,13 +6669,17 @@
 /area/barren/medical/research)
 "JZ" = (
 /obj/structure/girder,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Ka" = (
 /obj/structure/bed/chair/pew{
 	dir = 4
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Kc" = (
 /obj/structure/bed/chair/comfy/beige{
@@ -6323,7 +6708,9 @@
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/hardhat/orange,
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "Ki" = (
 /obj/structure/sink/bathroom{
@@ -6334,7 +6721,9 @@
 "Kk" = (
 /obj/effect/ai_node,
 /obj/structure/girder,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Kl" = (
 /obj/structure/closet/secure_closet/freezer/money,
@@ -6348,7 +6737,9 @@
 /area/barren/civilian/botany)
 "Ko" = (
 /obj/structure/ore_box,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Kp" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -6363,7 +6754,9 @@
 "Ks" = (
 /obj/item/organ/xenos/eggsac,
 /obj/effect/xenomorph/acid,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Kw" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -6375,7 +6768,9 @@
 /obj/structure/bed/chair/pew{
 	dir = 5
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Kz" = (
 /obj/structure/table/reinforced,
@@ -6392,7 +6787,9 @@
 /area/barren/medical)
 "KE" = (
 /obj/structure/girder,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "KF" = (
 /obj/structure/closet/secure_closet/atmos_personal,
@@ -6411,7 +6808,9 @@
 /obj/structure/barricade/guardrail{
 	dir = 8
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "KK" = (
 /obj/machinery/door/airlock/mainship/generic,
@@ -6452,11 +6851,15 @@
 /area/barren/medical/research)
 "Lb" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Lc" = (
 /obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "Lf" = (
 /obj/machinery/conveyor{
@@ -6472,18 +6875,24 @@
 /area/barren/misc/eastarmory)
 "Lh" = (
 /obj/effect/decal/cleanable/blood/writing,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Lj" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "Lk" = (
 /turf/closed/wall,
 /area/bigredv2/outside/e)
 "Lm" = (
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Ln" = (
 /obj/structure/bed/chair/wood,
@@ -6491,7 +6900,9 @@
 /area/barren/cave/lz1)
 "Lo" = (
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/se)
 "Lt" = (
 /obj/structure/grille/broken,
@@ -6518,7 +6929,9 @@
 /area/barren/medical/research)
 "Lz" = (
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "LA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6655,7 +7068,9 @@
 /area/barren/civilian/workdorm)
 "Mo" = (
 /obj/docking_port/stationary/crashmode,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "Mt" = (
 /obj/structure/rack,
@@ -6668,7 +7083,9 @@
 "Mx" = (
 /obj/item/lightstick/red/anchored,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/se)
 "My" = (
 /obj/machinery/power/apc,
@@ -6686,7 +7103,9 @@
 /area/bigredv2/caves/south)
 "MF" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "MG" = (
 /obj/structure/cargo_container/horizontal{
@@ -6717,7 +7136,9 @@
 /area/barren/medical)
 "MR" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "MS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6731,7 +7152,9 @@
 /area/bigredv2/outside/c)
 "MV" = (
 /obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "MW" = (
 /obj/structure/sign/poster,
@@ -6773,7 +7196,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Nk" = (
 /obj/structure/table/mainship,
@@ -6812,7 +7237,9 @@
 /area/barren/cave/lz2)
 "Np" = (
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "Nq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6993,7 +7420,9 @@
 /area/barren/civilian/botany)
 "Oz" = (
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "OB" = (
 /obj/structure/cable,
@@ -7001,7 +7430,9 @@
 /turf/open/floor/plating,
 /area/barren/cave/lz1)
 "OD" = (
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/ne)
 "OJ" = (
 /obj/structure/barricade/guardrail{
@@ -7014,16 +7445,22 @@
 /area/barren/civilian)
 "OK" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "OL" = (
 /obj/structure/razorwire,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "OM" = (
 /obj/structure/fence,
 /obj/effect/landmark/weed_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "OP" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -7090,7 +7527,9 @@
 /area/bigredv2/outside/e)
 "Pe" = (
 /obj/effect/spawner/random/toolbox,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "Pf" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -7162,7 +7601,9 @@
 /turf/open/floor/wood,
 /area/barren/security)
 "Pv" = (
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "Pw" = (
 /turf/open/floor,
@@ -7171,7 +7612,9 @@
 /obj/structure/barricade/guardrail{
 	dir = 8
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "PB" = (
 /turf/open/floor/wood,
@@ -7201,7 +7644,9 @@
 /obj/structure/barricade/guardrail{
 	dir = 1
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "PP" = (
 /obj/structure/closet/secure_closet/chemical/colony,
@@ -7210,7 +7655,9 @@
 "PQ" = (
 /obj/structure/cable,
 /obj/structure/closet/walllocker/hydrant/extinguisher,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "PT" = (
 /turf/open/floor/wood,
@@ -7227,7 +7674,9 @@
 /area/barren/cave/lz1)
 "PZ" = (
 /obj/item/organ/xenos/acidgland,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Qc" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -7249,7 +7698,9 @@
 /area/barren/cave/lz1)
 "Qk" = (
 /obj/item/organ/xenos/hivenode,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Qm" = (
 /obj/structure/cable,
@@ -7304,7 +7755,9 @@
 /area/bigredv2/caves/south)
 "QB" = (
 /obj/effect/landmark/weed_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "QC" = (
 /turf/open/lavaland/basalt/glowing,
@@ -7338,7 +7791,9 @@
 "QM" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "QN" = (
 /turf/open/floor/plating,
@@ -7360,7 +7815,9 @@
 /area/bigredv2/caves/southeast)
 "QT" = (
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "QV" = (
 /turf/closed/mineral/smooth/indestructible,
@@ -7432,7 +7889,9 @@
 "Rl" = (
 /obj/item/tool/pickaxe,
 /obj/item/ore/phoron,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "Rn" = (
 /obj/structure/cable,
@@ -7448,7 +7907,9 @@
 /area/barren/civilian)
 "Rq" = (
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Rs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7458,11 +7919,15 @@
 /area/barren/engie/engine)
 "Ru" = (
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Ry" = (
 /obj/structure/barricade/guardrail,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "RA" = (
 /turf/open/floor/plating,
@@ -7482,11 +7947,15 @@
 /area/shuttle/drop2/lz2)
 "RH" = (
 /obj/effect/landmark/weed_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "RI" = (
 /obj/structure/ore_box,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "RJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7507,7 +7976,9 @@
 /area/bigredv2/outside/general_offices)
 "RN" = (
 /obj/effect/landmark/weed_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/se)
 "RO" = (
 /obj/docking_port/stationary/crashmode,
@@ -7516,14 +7987,18 @@
 "RP" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/storage/bag/trash,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/n)
 "RQ" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/hardhat/orange,
 /obj/effect/decal/cleanable/blood,
 /obj/structure/fence,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "RS" = (
 /obj/structure/rack,
@@ -7584,7 +8059,9 @@
 /area/barren/civilian)
 "Si" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "Sk" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -7609,15 +8086,21 @@
 /area/barren/security)
 "Sr" = (
 /obj/item/lightstick/red/anchored,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "Su" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Sw" = (
 /obj/machinery/miner/damaged/platinum,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Sx" = (
 /obj/structure/table/reinforced/prison,
@@ -7628,7 +8111,9 @@
 /area/bigredv2/caves/southeast)
 "SA" = (
 /obj/effect/landmark/xeno_resin_wall,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "SC" = (
 /turf/open/floor/wood{
@@ -7648,11 +8133,15 @@
 /area/barren/civilian/workdorm)
 "SL" = (
 /obj/item/ore/phoron,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "SM" = (
 /obj/item/lightstick/red/anchored,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "SN" = (
 /obj/effect/decal/cleanable/blood/writing{
@@ -7662,13 +8151,17 @@
 /area/barren/security)
 "SO" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "SP" = (
 /obj/structure/bed/chair/pew{
 	dir = 6
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "SQ" = (
 /turf/open/floor/marking,
@@ -7683,7 +8176,9 @@
 "ST" = (
 /obj/structure/cable,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "SU" = (
 /obj/machinery/power/apc/drained,
@@ -7700,11 +8195,15 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 8
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "Ta" = (
 /obj/structure/lattice,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Tb" = (
 /obj/machinery/light{
@@ -7737,7 +8236,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 10
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Tp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7756,7 +8257,9 @@
 "Tv" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_wall,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "Tx" = (
 /obj/structure/rack,
@@ -7773,7 +8276,9 @@
 /area/barren/civilian)
 "TB" = (
 /obj/machinery/miner/damaged/platinum,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "TC" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -7837,12 +8342,16 @@
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "TV" = (
 /obj/item/tool/pickaxe,
 /obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "TW" = (
 /obj/item/toy/plush,
@@ -7856,7 +8365,9 @@
 /area/barren/medical/research)
 "Ub" = (
 /obj/effect/landmark/start/job/xenomorph,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Ud" = (
 /turf/open/floor/tile/blue/whiteblue{
@@ -7872,7 +8383,9 @@
 /area/barren/medical)
 "Ui" = (
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "Ul" = (
 /obj/machinery/light{
@@ -7886,7 +8399,9 @@
 "Un" = (
 /obj/structure/fence,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "Up" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7978,7 +8493,9 @@
 "UM" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/landmark/excavation_site_spawner,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "UN" = (
 /obj/structure/table/reinforced,
@@ -8004,7 +8521,9 @@
 /area/barren/security)
 "UW" = (
 /obj/effect/landmark/weapon_spawn/tier1_weapon_spawn,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "UX" = (
 /obj/effect/decal/woodsiding{
@@ -8033,7 +8552,9 @@
 "Vg" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/start/job/xenomorph,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "Vi" = (
 /obj/structure/bed/chair/wood/wings,
@@ -8086,12 +8607,16 @@
 	id = "TGMC_12";
 	name = "TGMC exit point 12"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "Vy" = (
 /obj/structure/fence,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "VA" = (
 /obj/machinery/door/airlock/mainship/generic{
@@ -8119,15 +8644,21 @@
 "VE" = (
 /obj/structure/lattice,
 /obj/effect/landmark/xeno_resin_wall,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "VF" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/core,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "VG" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "VH" = (
 /obj/structure/cable,
@@ -8135,7 +8666,9 @@
 /area/prison/laundry)
 "VJ" = (
 /obj/item/organ/xenos/acidgland,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "VL" = (
 /turf/open/floor/plating/warning{
@@ -8176,7 +8709,9 @@
 "VX" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "VY" = (
 /obj/machinery/light_construct{
@@ -8187,7 +8722,9 @@
 /area/barren/security)
 "VZ" = (
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Wa" = (
 /obj/structure/cable,
@@ -8200,7 +8737,9 @@
 /area/bigredv2/outside/w)
 "Wb" = (
 /turf/closed/brock,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "We" = (
 /obj/structure/window/reinforced/toughened{
@@ -8272,11 +8811,15 @@
 /area/barren/medical)
 "WD" = (
 /obj/structure/lattice,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "WF" = (
 /obj/effect/ai_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "WG" = (
 /obj/structure/window/framed/colony,
@@ -8306,7 +8849,9 @@
 /area/barren/cave/lz2)
 "WR" = (
 /obj/effect/decal/cleanable/blood/writing,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "WS" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -8336,7 +8881,9 @@
 /area/barren/misc/genstorage)
 "Xd" = (
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/e)
 "Xe" = (
 /obj/structure/window/framed/colony,
@@ -8364,7 +8911,9 @@
 /area/barren/civilian/workdorm)
 "Xj" = (
 /obj/effect/decal/remains/human,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Xm" = (
 /obj/structure/filingcabinet,
@@ -8372,7 +8921,9 @@
 /turf/open/floor/tile/dark2,
 /area/bigredv2/outside/general_offices)
 "Xo" = (
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "Xp" = (
 /obj/structure/barricade/guardrail{
@@ -8416,7 +8967,9 @@
 /area/barren/security)
 "XB" = (
 /obj/effect/landmark/xeno_resin_wall,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "XD" = (
 /obj/structure/cable,
@@ -8491,7 +9044,9 @@
 /area/barren/civilian)
 "Yd" = (
 /turf/open/space/basic,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Yh" = (
 /obj/structure/bed,
@@ -8513,7 +9068,9 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "Ys" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8537,7 +9094,9 @@
 	id = "TGMC_22";
 	name = "TGMC exit point 22"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "YA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8567,7 +9126,9 @@
 /turf/open/floor/mainship/black/full,
 /area/barren/security)
 "YI" = (
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southwest)
 "YM" = (
 /obj/machinery/door/airlock/mainship/generic{
@@ -8586,12 +9147,16 @@
 /area/barren/civilian/cook)
 "YR" = (
 /obj/item/organ/xenos/plasmavessel,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "YS" = (
 /obj/item/lightstick/red/anchored,
 /obj/structure/cable,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "YX" = (
 /obj/structure/table/reinforced,
@@ -8614,7 +9179,9 @@
 /area/barren/medical/research)
 "Zb" = (
 /obj/effect/landmark/weed_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Zc" = (
 /turf/open/floor/plating/warning{
@@ -8635,7 +9202,9 @@
 /turf/open/lavaland/lava/side,
 /area/barren)
 "Zg" = (
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Zh" = (
 /obj/structure/table/reinforced/prison,
@@ -8675,7 +9244,9 @@
 /area/barren/security)
 "Zq" = (
 /obj/item/organ/xenos/eggsac,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "Zs" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -8699,7 +9270,9 @@
 /area/bigredv2/outside/general_offices)
 "Zz" = (
 /obj/item/organ/xenos/acidgland,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/southeast)
 "ZB" = (
 /obj/structure/cargo_container/horizontal,
@@ -8717,7 +9290,9 @@
 "ZD" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/caves/south)
 "ZE" = (
 /obj/effect/landmark/patrol_point{
@@ -8745,7 +9320,9 @@
 /turf/closed/brock,
 /area/bigredv2/outside/c)
 "ZL" = (
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/c)
 "ZM" = (
 /obj/structure/filingcabinet,
@@ -8756,7 +9333,9 @@
 /turf/open/floor/wood,
 /area/barren/security)
 "ZN" = (
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/w)
 "ZO" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
@@ -13271,7 +13850,7 @@ rK
 rK
 rK
 rK
-QR
+fM
 qj
 Gv
 mP
@@ -13526,9 +14105,9 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 qj
 Gv
 mP
@@ -13783,9 +14362,9 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 qj
 Gv
 mP
@@ -14039,10 +14618,10 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 qj
 Gv
 mP
@@ -14294,11 +14873,11 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 rK
 ak
 Gv
@@ -14540,7 +15119,7 @@ rK
 rK
 rK
 lf
-QR
+fM
 rK
 rK
 rK
@@ -14550,12 +15129,12 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
 rK
 ak
 Gv
@@ -14795,23 +15374,23 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 Vx
 rK
 rK
 rK
 rK
-QR
+fM
 AB
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
 rK
 rK
 iG
@@ -15052,20 +15631,20 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
 AB
-QR
-QR
-QR
+fM
+fM
+fM
 nu
 nu
 nu
@@ -15308,24 +15887,24 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 ca
-QR
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
+fM
 it
-QR
-QR
-QR
+fM
+fM
+fM
 nu
-QR
-QR
+fM
+fM
 rK
 rK
 ak
@@ -15567,22 +16146,22 @@ rK
 rK
 QR
 QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
 AB
 AB
 AB
 AB
 nu
-QR
-QR
+fM
+fM
 rK
 rK
 ak
@@ -15824,18 +16403,18 @@ rK
 sO
 QR
 QR
-QR
-QR
+fM
+fM
 rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
 AB
 rM
 AB
@@ -16079,21 +16658,21 @@ rK
 rK
 rK
 QR
+fM
 QR
-QR
-QR
-QR
+fM
+fM
 rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
+fM
 nu
 rK
 rK
@@ -16338,7 +16917,7 @@ rK
 QR
 QR
 QR
-QR
+fM
 EI
 rK
 rK
@@ -16349,8 +16928,8 @@ rK
 rK
 ca
 Ui
-QR
-QR
+fM
+fM
 iT
 rK
 rK
@@ -16595,21 +17174,21 @@ rK
 QR
 QR
 QR
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 nu
-QR
+fM
 rK
 rK
 rK
@@ -16852,9 +17431,9 @@ rK
 rK
 QR
 QR
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 rK
@@ -16863,11 +17442,11 @@ rK
 rK
 rK
 rK
-QR
-QR
+fM
+fM
 nu
-QR
-QR
+fM
+fM
 rK
 rK
 rK
@@ -17107,11 +17686,11 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -17120,11 +17699,11 @@ rK
 rK
 rK
 rK
-QR
-QR
+fM
+fM
 nu
-QR
-QR
+fM
+fM
 rK
 rK
 rK
@@ -17365,10 +17944,10 @@ rK
 rK
 rK
 ca
-QR
-QR
+fM
+fM
 ca
-QR
+fM
 rK
 rK
 rK
@@ -17378,11 +17957,11 @@ rK
 rK
 rK
 rK
-QR
+fM
 nu
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 rK
@@ -17621,11 +18200,11 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -17635,12 +18214,12 @@ rK
 rK
 rK
 rK
-QR
+fM
 nu
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -17877,11 +18456,11 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -17894,13 +18473,13 @@ rK
 rK
 rK
 nu
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 AB
-QR
+fM
 rK
 rK
 rK
@@ -18133,12 +18712,12 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -18151,15 +18730,15 @@ rK
 rK
 rK
 iT
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 AB
 ca
-QR
-QR
+fM
+fM
 rK
 rK
 rK
@@ -18390,12 +18969,12 @@ rK
 rK
 rK
 rK
-QR
+fM
 Ui
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 Bi
 Bi
@@ -18408,17 +18987,17 @@ rK
 rK
 nu
 nu
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 AB
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -18646,12 +19225,12 @@ Uy
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
 rK
 rK
 Bi
@@ -18664,20 +19243,20 @@ Bi
 rK
 rK
 nu
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
 AB
-QR
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -18904,11 +19483,11 @@ rK
 rK
 rK
 ca
-QR
-QR
+fM
+fM
 ca
-QR
-QR
+fM
+fM
 rK
 rK
 Bi
@@ -18919,29 +19498,29 @@ Sp
 bm
 Bi
 rK
-QR
+fM
 nu
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
-QR
+fM
 AB
 ca
-QR
+fM
 Ui
-QR
+fM
 ca
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 rK
 rK
 rK
-QR
+fM
 ZN
 ZN
 ZN
@@ -19160,10 +19739,10 @@ Uy
 rK
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -19176,29 +19755,29 @@ Gj
 Sp
 Bi
 rK
-QR
+fM
 nu
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
 rK
 rK
-QR
-QR
+fM
+fM
 ZN
 ZN
 ZN
@@ -19417,9 +19996,9 @@ Uy
 rK
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 rK
@@ -19436,26 +20015,26 @@ rK
 rK
 nu
 ca
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
 ZN
 ZN
 ZN
@@ -19673,10 +20252,10 @@ aI
 Uy
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -19702,17 +20281,17 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
 ZN
 ZN
 ZN
@@ -19930,9 +20509,9 @@ aI
 Uy
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 rK
@@ -19949,9 +20528,9 @@ rq
 Bi
 rK
 nu
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 rK
@@ -19961,15 +20540,15 @@ rK
 rK
 rK
 ca
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
 ca
-QR
-QR
+fM
+fM
 ZN
 ZN
 ZN
@@ -20187,9 +20766,9 @@ aI
 Uy
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 GK
 rK
@@ -20207,8 +20786,8 @@ Bi
 rK
 nu
 nu
-QR
-QR
+fM
+fM
 rK
 rK
 rK
@@ -20219,14 +20798,14 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+fM
 ZW
 ZN
 ZN
@@ -20444,9 +21023,9 @@ aI
 Uy
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 GW
 be
@@ -20478,12 +21057,12 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
+fM
 ZW
 ZW
 ZW
@@ -20700,10 +21279,10 @@ aI
 aI
 Uy
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 GW
 Fg
@@ -20737,10 +21316,10 @@ Bi
 Bi
 Bi
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 ZN
 ZW
 ZW
@@ -20957,11 +21536,11 @@ aI
 aI
 Uy
 rK
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 Xe
 ju
 Pc
@@ -20995,9 +21574,9 @@ Sp
 Bi
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 ZN
 ZN
 ZN
@@ -21214,11 +21793,11 @@ aI
 aI
 Uy
 rK
-QR
-QR
+fM
+fM
 ca
-QR
-QR
+fM
+fM
 Xe
 kV
 dI
@@ -21254,7 +21833,7 @@ rK
 rK
 rK
 rK
-QR
+fM
 ZN
 ZN
 ZN
@@ -21471,11 +22050,11 @@ aI
 aI
 Uy
 rK
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 Xe
 Pc
 UV
@@ -21491,9 +22070,9 @@ dS
 GW
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 rK
@@ -21728,10 +22307,10 @@ aI
 aI
 Uy
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 GW
 Ml
@@ -21748,10 +22327,10 @@ Aq
 Pn
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 rK
 Bi
@@ -21985,9 +22564,9 @@ aI
 aI
 Uy
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 GW
@@ -22006,9 +22585,9 @@ GW
 rK
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 Bi
@@ -22242,9 +22821,9 @@ aI
 aI
 Uy
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 GW
@@ -22499,10 +23078,10 @@ aI
 aI
 Uy
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -22520,9 +23099,9 @@ DN
 GW
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 Bi
@@ -22757,10 +23336,10 @@ aI
 Uy
 rK
 rK
-QR
+fM
 ca
-QR
-QR
+fM
+fM
 rK
 rK
 bB
@@ -22778,8 +23357,8 @@ GW
 rK
 rK
 ca
-QR
-QR
+fM
+fM
 rK
 rK
 Bi
@@ -22796,7 +23375,7 @@ Bi
 rK
 rK
 xI
-QR
+fM
 ZN
 ZN
 ZN
@@ -23015,9 +23594,9 @@ Uy
 rK
 rK
 rK
-QR
+fM
 ca
-QR
+fM
 rK
 rK
 rK
@@ -23034,10 +23613,10 @@ pv
 GW
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 Bi
 lQ
@@ -23272,10 +23851,10 @@ Uy
 rK
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 rK
 GW
@@ -23291,10 +23870,10 @@ vi
 GW
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 Bi
 mv
@@ -23310,7 +23889,7 @@ Bi
 rK
 rK
 rK
-QR
+fM
 ZN
 ZN
 ZN
@@ -23530,9 +24109,9 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 rK
 rK
 GW
@@ -23548,10 +24127,10 @@ GW
 GW
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 Bi
 Bi
@@ -23566,8 +24145,8 @@ Bi
 Bi
 rK
 rK
-QR
-QR
+fM
+fM
 ZN
 ZN
 ZN
@@ -23805,10 +24384,10 @@ GW
 GW
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 Bi
 dQ
@@ -23822,9 +24401,9 @@ tF
 BS
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 ZN
 ZN
 ZN
@@ -24044,10 +24623,10 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -24061,11 +24640,11 @@ bF
 GW
 rK
 rK
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 rK
 Bi
 ul
@@ -24075,13 +24654,13 @@ Yh
 wQ
 Bi
 rK
-QR
+fM
 BS
 og
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 ZN
 ZN
 ZN
@@ -24301,10 +24880,10 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 rK
 rK
 rK
@@ -24318,11 +24897,11 @@ GX
 GW
 rK
 rK
-QR
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
+fM
 rK
 Bi
 Bi
@@ -24332,13 +24911,13 @@ Bi
 Bi
 Bi
 rK
-QR
+fM
 BS
 yE
-QR
-QR
-QR
-QR
+fM
+fM
+fM
+fM
 ZN
 ZN
 qn

--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -69,6 +69,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/barren/cave/lz2)
+"ar" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking,
+/area/bigredv2/outside/c)
 "as" = (
 /turf/open/lavaland/lava/side{
 	dir = 4
@@ -89,6 +94,13 @@
 	dir = 5
 	},
 /area/barren/security)
+"ax" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/c)
 "ay" = (
 /obj/machinery/light{
 	dir = 4
@@ -99,6 +111,10 @@
 	},
 /turf/open/floor/wood,
 /area/barren/cave/lz1)
+"aA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking,
+/area/bigredv2/outside/c)
 "aB" = (
 /obj/structure/barricade/guardrail{
 	dir = 8
@@ -318,6 +334,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
+"bK" = (
+/obj/machinery/miner/damaged,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/n)
 "bL" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/lavaland/basalt{
@@ -470,6 +493,11 @@
 /obj/item/trash/sosjerky,
 /turf/open/floor/wood,
 /area/barren/civilian)
+"cE" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/barren/engie/engine)
 "cG" = (
 /obj/structure/barricade/guardrail,
 /turf/open/floor/plating,
@@ -763,6 +791,13 @@
 "eb" = (
 /turf/open/floor/plating,
 /area/barren/cave/lz1)
+"ed" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/caves/south)
 "eg" = (
 /obj/structure/disposalpipe/junction/yjunc{
 	dir = 1
@@ -1036,6 +1071,15 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/barren/civilian)
+"fr" = (
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/n)
 "fs" = (
 /obj/effect/decal/woodsiding,
 /obj/effect/ai_node,
@@ -1073,6 +1117,7 @@
 "fz" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
 "fA" = (
@@ -1115,6 +1160,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
+"fL" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/barren/civilian)
 "fM" = (
 /turf/open/lavaland/basalt{
 	baseturfs = /turf/open/lavaland/basalt
@@ -1534,6 +1585,13 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/outside/ne)
+"hF" = (
+/obj/effect/decal/remains/human,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/caves/south)
 "hH" = (
 /turf/open/floor/grimy,
 /area/barren/civilian)
@@ -1595,6 +1653,10 @@
 	icon_state = "carpet5-1"
 	},
 /area/bigredv2/outside/w)
+"ie" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/barren/civilian)
 "ig" = (
 /obj/structure/stairs,
 /turf/open/floor/prison/bright_clean/two,
@@ -1830,6 +1892,10 @@
 /obj/machinery/door/airlock/colony/research,
 /turf/open/floor/prison/sterilewhite,
 /area/barren/medical/research)
+"jl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/dmg3,
+/area/bigredv2/outside/c)
 "jm" = (
 /obj/machinery/science/analyser,
 /turf/open/floor/prison/sterilewhite,
@@ -1868,6 +1934,10 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/caves/south)
+"jz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/vault,
+/area/prison/laundry)
 "jA" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 8
@@ -1985,6 +2055,7 @@
 /area/barren/cave/lz1)
 "kd" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/barren/civilian/workdorm)
 "kf" = (
@@ -2069,6 +2140,7 @@
 /area/barren/engie/engine)
 "kA" = (
 /obj/item/trash/cigbutt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/marking,
 /area/bigredv2/outside/c)
 "kC" = (
@@ -2509,6 +2581,13 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/outside/c)
+"nf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/barren/security)
 "ng" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/decal/cleanable/cobweb2,
@@ -2549,6 +2628,7 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/barren/civilian)
 "nq" = (
@@ -2569,6 +2649,7 @@
 "nw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/barren/civilian/workdorm)
 "nz" = (
@@ -2637,6 +2718,12 @@
 /obj/structure/cable,
 /turf/open/floor/freezer,
 /area/barren/medical/chemistry)
+"nM" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/caves/southeast)
 "nN" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -2669,12 +2756,25 @@
 /obj/structure/table,
 /turf/open/floor/wood,
 /area/barren/civilian/cook)
+"nY" = (
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/n)
 "nZ" = (
 /obj/structure/flora/pottedplant/twentyone,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/trash/sosjerky,
 /turf/open/floor,
 /area/barren/civilian/workdorm)
+"oa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/n)
 "oc" = (
 /obj/structure/filingcabinet/security,
 /obj/effect/decal/cleanable/dirt,
@@ -2749,6 +2849,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/hydro,
 /area/barren/civilian/botany)
+"oA" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/caves/south)
 "oB" = (
 /obj/machinery/landinglight/ds2{
 	dir = 8
@@ -2802,6 +2908,13 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom,
 /turf/open/floor/freezer,
 /area/barren/civilian/cook)
+"oM" = (
+/obj/item/tool/pickaxe,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/c)
 "oO" = (
 /obj/structure/bed/alien,
 /obj/item/bedsheet,
@@ -2952,6 +3065,10 @@
 	name = "medical"
 	},
 /area/barren/medical)
+"pC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/vault,
+/area/barren/civilian)
 "pE" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -3053,6 +3170,13 @@
 /obj/structure/closet/crate/freezer/rations,
 /turf/open/floor,
 /area/barren/misc/eastarmory)
+"qi" = (
+/obj/item/tool/pickaxe,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/w)
 "qj" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -3061,6 +3185,13 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/barren/cave/lz2)
+"qk" = (
+/obj/item/lightstick/red/anchored,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/c)
 "ql" = (
 /obj/structure/cable,
 /obj/machinery/power/apc,
@@ -3090,6 +3221,11 @@
 	dir = 4
 	},
 /area/barren)
+"qt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/barren/civilian)
 "qv" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -3492,6 +3628,11 @@
 /obj/structure/table,
 /turf/open/floor,
 /area/barren/civilian)
+"sC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/barren/engie/engine)
 "sE" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained{
@@ -3718,6 +3859,7 @@
 "tF" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/lavaland/basalt{
 	baseturfs = /turf/open/lavaland/basalt
 	},
@@ -3858,6 +4000,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
 "uq" = (
@@ -3873,6 +4016,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"uu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/barren/misc/genstorage)
 "uv" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/toolbox,
@@ -3883,6 +4030,7 @@
 /turf/open/floor/mainship/black/full,
 /area/barren/security)
 "uB" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 1
 	},
@@ -4046,6 +4194,7 @@
 "vy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/lavaland/basalt{
 	baseturfs = /turf/open/lavaland/basalt
 	},
@@ -4100,6 +4249,7 @@
 /area/barren/misc/genstorage)
 "vN" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/redtaupe,
 /area/barren/security)
 "vO" = (
@@ -4213,6 +4363,11 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/outside/e)
+"wr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/black/full,
+/area/barren/security)
 "wy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -4316,6 +4471,11 @@
 /turf/open/floor/plating/dmg3,
 /turf/open/floor/plating/dmg2,
 /area/bigredv2/outside/c)
+"xb" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking,
+/area/bigredv2/outside/c)
 "xc" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -4415,6 +4575,11 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/closed/wall,
 /area/barren/security)
+"xL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/barren/civilian)
 "xM" = (
 /obj/structure/rack,
 /turf/open/floor,
@@ -4514,6 +4679,11 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/caves/southwest)
+"yn" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/grimy,
+/area/barren/civilian)
 "yo" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -4528,6 +4698,7 @@
 /area/barren/misc/eastarmory)
 "yr" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/grimy,
 /area/barren/civilian/workdorm)
 "ys" = (
@@ -4546,6 +4717,13 @@
 	dir = 1
 	},
 /area/barren/medical)
+"yB" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/w)
 "yC" = (
 /obj/structure/table,
 /obj/item/trash/tray,
@@ -4588,6 +4766,10 @@
 	dir = 1
 	},
 /area/bigredv2/outside/c)
+"yT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/barren/civilian)
 "yV" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -4687,6 +4869,14 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/outside/e)
+"zu" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/c)
 "zw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/hydro,
@@ -4770,6 +4960,15 @@
 	},
 /turf/open/floor/wood,
 /area/barren/cave/lz1)
+"zU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/barren/security)
+"zW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/barren/civilian/cook)
 "zY" = (
 /obj/structure/ore_box,
 /turf/open/lavaland/basalt{
@@ -4792,6 +4991,13 @@
 /obj/machinery/faxmachine/research,
 /turf/open/floor/prison/sterilewhite,
 /area/barren/medical/research)
+"Af" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/e)
 "Ag" = (
 /turf/open/floor/marking/delivery,
 /area/barren/cave/lz1)
@@ -4956,6 +5162,12 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/vault,
 /area/prison/laundry)
+"AW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/nw)
 "AX" = (
 /obj/structure/rack,
 /obj/item/ammo_magazine/shotgun/buckshot,
@@ -5051,6 +5263,11 @@
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/prison,
 /area/ai_monitored/storage/secure)
+"Bu" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/barren/misc/genstorage)
 "Bw" = (
 /obj/structure/cable,
 /turf/open/floor/plating/dmg3,
@@ -5153,6 +5370,7 @@
 /obj/item/clothing/head/warning_cone,
 /obj/structure/lattice,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/lavaland/basalt{
 	baseturfs = /turf/open/lavaland/basalt
 	},
@@ -5442,6 +5660,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/red,
 /area/barren/security)
+"Dw" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/n)
 "DB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
@@ -5491,6 +5716,10 @@
 	dir = 10
 	},
 /area/barren/security)
+"DQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/kitchen,
+/area/barren/civilian/cook)
 "DR" = (
 /obj/effect/decal/woodsiding{
 	dir = 1
@@ -5562,6 +5791,7 @@
 /area/bigredv2/outside/c)
 "Ej" = (
 /obj/effect/decal/cleanable/blood/writing,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/barren/civilian/cook)
 "Em" = (
@@ -5653,6 +5883,13 @@
 "EB" = (
 /turf/closed/brock,
 /area/bigredv2/outside/e)
+"ED" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/w)
 "EG" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
@@ -6044,6 +6281,11 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/outside/c)
+"GC" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/barren/engie/engine)
 "GD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/lavaland/basalt{
@@ -6123,6 +6365,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/marking,
 /area/bigredv2/outside/c)
 "Hb" = (
@@ -6223,6 +6466,10 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/outside/w)
+"HF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/barren/engie/engine)
 "HG" = (
 /turf/open/floor/tile/red/redtaupe,
 /area/barren/security)
@@ -6408,6 +6655,13 @@
 /obj/structure/sign/science,
 /turf/open/floor/freezer,
 /area/barren/medical/research)
+"IH" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/e)
 "IK" = (
 /obj/structure/table/reinforced/prison,
 /turf/open/floor/prison/bright_clean/two,
@@ -6458,6 +6712,7 @@
 "IZ" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/freezer,
 /area/barren/civilian/workdorm)
 "Ja" = (
@@ -6802,6 +7057,10 @@
 /obj/item/trash/raisins,
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/barren/medical)
+"KD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/grimy,
+/area/barren/civilian)
 "KE" = (
 /obj/structure/girder,
 /turf/open/lavaland/basalt{
@@ -6892,6 +7151,7 @@
 /area/barren/misc/eastarmory)
 "Lh" = (
 /obj/effect/decal/cleanable/blood/writing,
+/obj/effect/landmark/weed_node,
 /turf/open/lavaland/basalt{
 	baseturfs = /turf/open/lavaland/basalt
 	},
@@ -6961,6 +7221,12 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/barren/misc/refinery)
+"LC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/e)
 "LD" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -7013,6 +7279,20 @@
 	},
 /turf/open/floor,
 /area/barren/civilian)
+"LQ" = (
+/obj/item/assembly/mousetrap/armed,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/caves/southeast)
+"LT" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/c)
 "LW" = (
 /obj/structure/sign/poster,
 /obj/machinery/computer/nuke_disk_generator/green,
@@ -7160,6 +7440,7 @@
 "MS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red,
 /area/barren/security)
 "MT" = (
@@ -7441,6 +7722,11 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/caves/southeast)
+"OA" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red,
+/area/barren/security)
 "OB" = (
 /obj/structure/cable,
 /obj/structure/window/framed/colony/reinforced,
@@ -7640,6 +7926,12 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/barren/cave/lz1)
+"PE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/w)
 "PH" = (
 /obj/structure/cable,
 /turf/open/floor/freezer,
@@ -7650,6 +7942,13 @@
 	icon_state = "wood-broken4"
 	},
 /area/barren/civilian/cook)
+"PK" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/c)
 "PL" = (
 /turf/closed/wall,
 /area/barren/engie/two)
@@ -7757,6 +8056,10 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
+"Qx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/barren/medical/research)
 "Qy" = (
 /obj/structure/closet/wardrobe/science_white,
 /turf/open/floor/prison/sterilewhite,
@@ -7845,6 +8148,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor,
 /area/barren/cave/lz1)
+"QZ" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/kitchen,
+/area/barren/civilian/cook)
 "Ra" = (
 /obj/structure/cable,
 /turf/open/floor/plating/dmg1,
@@ -7943,6 +8251,13 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/outside/c)
+"Rz" = (
+/obj/item/tool/pickaxe,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/caves/southwest)
 "RA" = (
 /turf/open/floor/plating,
 /area/bigredv2/outside/c)
@@ -8096,6 +8411,15 @@
 /obj/structure/largecrate/random/case,
 /turf/open/floor,
 /area/barren/misc/genstorage)
+"Sn" = (
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/c)
 "Sp" = (
 /turf/open/floor/prison/bright_clean/two,
 /area/barren/security)
@@ -8139,6 +8463,12 @@
 	icon_state = "wood-broken6"
 	},
 /area/bigredv2/outside/general_offices)
+"SD" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/kitchen,
+/area/barren/civilian/cook)
 "SE" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/corpsespawner/chef,
@@ -8150,6 +8480,10 @@
 	},
 /turf/open/floor/grimy,
 /area/barren/civilian/workdorm)
+"SK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/barren/medical/research)
 "SL" = (
 /obj/item/ore/phoron,
 /turf/open/lavaland/basalt{
@@ -8190,6 +8524,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/barren/security)
 "ST" = (
@@ -8382,6 +8717,11 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/barren/medical/research)
+"TZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/grimy,
+/area/barren/civilian/workdorm)
 "Ub" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/lavaland/basalt{
@@ -8637,6 +8977,11 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/caves/south)
+"Vz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/barren/medical/research)
 "VA" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 2
@@ -8709,6 +9054,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/kitchen,
 /area/barren/civilian/cook)
 "VQ" = (
@@ -8718,6 +9064,10 @@
 	dir = 8
 	},
 /area/barren/medical)
+"VR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/barren/misc/refinery)
 "VS" = (
 /obj/structure/prop/mainship/hangar_stencil,
 /obj/effect/decal/warning_stripes/thick{
@@ -8926,6 +9276,7 @@
 "Xi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
+/obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/barren/civilian/workdorm)
 "Xj" = (
@@ -8959,6 +9310,10 @@
 	},
 /turf/open/floor/wood,
 /area/barren/security)
+"Xs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/c)
 "Xt" = (
 /obj/structure/barricade/guardrail,
 /obj/structure/barricade/guardrail{
@@ -9091,9 +9446,15 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/caves/southwest)
+"Yr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/barren/civilian)
 "Ys" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/writing,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/red/redtaupe{
 	dir = 4
 	},
@@ -9108,6 +9469,14 @@
 	dir = 6
 	},
 /area/barren/medical)
+"Yx" = (
+/obj/structure/lattice,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/c)
 "Yz" = (
 /obj/effect/landmark/patrol_point{
 	id = "TGMC_22";
@@ -9161,6 +9530,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/freezer,
 /area/barren/civilian/cook)
+"YP" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/n)
 "YQ" = (
 /turf/open/floor/freezer,
 /area/barren/civilian/cook)
@@ -9261,6 +9637,10 @@
 	dir = 1
 	},
 /area/barren/security)
+"Zp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/barren/civilian/cook)
 "Zq" = (
 /obj/item/organ/xenos/eggsac,
 /turf/open/lavaland/basalt{
@@ -9275,6 +9655,13 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/barren/misc/genstorage)
+"Zv" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/caves/southeast)
 "Zw" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -15996,7 +16383,7 @@ ZN
 ZN
 YI
 YI
-YI
+QB
 Dq
 YI
 HQ
@@ -16769,7 +17156,7 @@ YI
 YI
 YI
 Dq
-YI
+QB
 YI
 Jv
 YI
@@ -20366,7 +20753,7 @@ ZN
 YI
 YI
 YI
-YI
+QB
 YI
 YI
 HQ
@@ -20874,11 +21261,11 @@ ZW
 ZW
 ZW
 ZN
-ZN
+PE
 BL
 HC
 YI
-YI
+QB
 YI
 YI
 HQ
@@ -21563,7 +21950,7 @@ fM
 Xe
 ju
 Pc
-OU
+zU
 OU
 Dm
 Dm
@@ -21900,10 +22287,10 @@ ZN
 ZN
 ua
 ZN
-AE
+qi
 ZN
 ZN
-ZN
+PE
 ZN
 YI
 YI
@@ -21914,7 +22301,7 @@ HQ
 YI
 YI
 YI
-YI
+QB
 YI
 YI
 YI
@@ -22165,7 +22552,7 @@ ZW
 YI
 hc
 ub
-YI
+QB
 YI
 HQ
 Sw
@@ -22605,7 +22992,7 @@ rK
 rK
 rK
 fM
-fM
+AW
 fM
 rK
 rK
@@ -22686,7 +23073,7 @@ Su
 YI
 YI
 YI
-YI
+QB
 dF
 HQ
 HQ
@@ -23365,7 +23752,7 @@ bB
 GW
 Nw
 kq
-OU
+zU
 Pp
 fS
 CW
@@ -23388,7 +23775,7 @@ Sx
 su
 ux
 Hv
-rD
+wr
 re
 Bi
 rK
@@ -23447,7 +23834,7 @@ ZW
 ZW
 ZW
 ZN
-ub
+Rz
 YI
 YI
 YI
@@ -23626,14 +24013,14 @@ HP
 aC
 zN
 CW
-vQ
+OA
 zI
 pv
 GW
 rK
 rK
 fM
-fM
+AW
 fM
 fM
 rK
@@ -23707,15 +24094,15 @@ ZN
 YI
 YI
 YI
+QB
 YI
 YI
-YI
-YI
+QB
 HQ
 HQ
 eT
 YI
-YI
+QB
 HQ
 HQ
 HQ
@@ -23958,7 +24345,7 @@ SL
 ZN
 ZN
 ZN
-ZN
+PE
 IE
 ZN
 YI
@@ -24218,7 +24605,7 @@ ZN
 ZN
 It
 ZN
-YI
+QB
 YI
 YI
 YI
@@ -24420,7 +24807,7 @@ tF
 BS
 rK
 rK
-fM
+AW
 fM
 fM
 ZN
@@ -24644,7 +25031,7 @@ rK
 rK
 fM
 fM
-fM
+AW
 fM
 rK
 rK
@@ -24653,7 +25040,7 @@ rK
 rK
 GW
 wX
-Zo
+nf
 gP
 bF
 GW
@@ -24662,7 +25049,7 @@ rK
 fM
 fM
 fM
-fM
+AW
 fM
 rK
 Bi
@@ -24731,13 +25118,13 @@ ZW
 ZN
 ZN
 HC
-ZN
+PE
 YI
 HQ
 HQ
 HQ
 YI
-YI
+QB
 HQ
 HQ
 HQ
@@ -24977,7 +25364,7 @@ ZW
 ZW
 ZN
 zQ
-ZN
+PE
 ZN
 ZW
 ZW
@@ -24986,7 +25373,7 @@ ZW
 ZW
 ZN
 ZN
-ZN
+PE
 ZN
 ZN
 YI
@@ -25193,7 +25580,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 ZN
 ZN
 ZN
@@ -25228,10 +25615,10 @@ ZN
 ZN
 ZN
 ZN
-ZN
+PE
 qn
 ZN
-ZN
+PE
 ZN
 zQ
 qn
@@ -25413,11 +25800,11 @@ al
 al
 gs
 gs
+bj
 gs
 gs
 gs
-gs
-gs
+bj
 gs
 gs
 al
@@ -25429,24 +25816,24 @@ ep
 GW
 CY
 CY
-CY
+YP
 CY
 cb
+bj
+gs
+al
+al
+al
+al
+al
+al
+al
+al
+al
+bj
 gs
 gs
-al
-al
-al
-al
-al
-al
-al
-al
-al
-gs
-gs
-gs
-gs
+bj
 gs
 gs
 gs
@@ -25741,7 +26128,7 @@ ZW
 ZW
 ZN
 ZN
-ZN
+PE
 ZN
 ZN
 ZN
@@ -25750,7 +26137,7 @@ ZN
 ZN
 zQ
 zQ
-zQ
+yB
 ZN
 ZW
 ZW
@@ -25933,10 +26320,10 @@ gs
 gs
 gs
 gs
+bj
 gs
 gs
-gs
-gs
+bj
 gs
 gs
 gs
@@ -25962,7 +26349,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 al
 ZW
@@ -26003,7 +26390,7 @@ ZN
 ZN
 ZN
 ZN
-ZN
+PE
 ZN
 ZN
 ZN
@@ -26012,13 +26399,13 @@ ZN
 ZW
 ZW
 ZN
+PE
 ZN
-ZN
-ZN
+PE
 ZN
 ZN
 YI
-YI
+QB
 YI
 YI
 HQ
@@ -26182,6 +26569,11 @@ aI
 ah
 al
 gs
+bj
+gs
+gs
+gs
+bj
 gs
 gs
 gs
@@ -26191,20 +26583,15 @@ gs
 gs
 gs
 gs
+bj
+gs
+bK
 gs
 gs
+YP
 gs
 gs
-gs
-gs
-gs
-BX
-gs
-gs
-CY
-gs
-gs
-gs
+bj
 gs
 al
 al
@@ -26472,7 +26859,7 @@ al
 al
 gs
 gs
-gs
+bj
 gs
 gs
 gs
@@ -26705,7 +27092,7 @@ xS
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 gs
@@ -26732,7 +27119,7 @@ gs
 gs
 gs
 cb
-gs
+bj
 al
 al
 al
@@ -26774,27 +27161,27 @@ ZW
 ZN
 ZN
 ZN
-ZN
+ED
 ZN
 ZN
 ZN
 zQ
+PE
 ZN
 ZN
 ZN
+PE
 ZN
-ZN
-ZN
-ZN
+PE
 ZN
 ZW
 HQ
 YI
 YI
+QB
 YI
 YI
-YI
-YI
+QB
 YI
 YI
 YI
@@ -26959,28 +27346,28 @@ TO
 TO
 TO
 Bb
+bj
 gs
 gs
 gs
 gs
 gs
 gs
-gs
-gs
+bj
 gs
 al
 al
 al
 al
 Ak
+YP
 CY
-CY
 gs
 gs
+bj
 gs
 gs
-gs
-gs
+bj
 al
 al
 gs
@@ -27028,7 +27415,7 @@ gy
 ZN
 ZN
 ZN
-ZN
+PE
 ZN
 ZN
 ZN
@@ -27241,7 +27628,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 gs
@@ -27478,7 +27865,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 al
@@ -27501,11 +27888,11 @@ gs
 gs
 Bo
 gs
+bj
 gs
 gs
 gs
-gs
-gs
+bj
 gs
 ZW
 ZW
@@ -27537,7 +27924,7 @@ US
 ZW
 xX
 ZN
-ZN
+PE
 ZN
 ZN
 ZN
@@ -27554,19 +27941,19 @@ ZN
 ZN
 ZN
 ZN
+PE
 ZN
-ZN
-ZN
+PE
 ZW
 ZW
 ZK
 ZK
 ZL
+RH
 ZL
 ZL
 ZL
-ZL
-ZL
+RH
 ZL
 ZK
 Zd
@@ -27725,19 +28112,19 @@ ah
 al
 al
 aZ
-Px
+fr
 Px
 gs
-gs
+bj
 aB
 gs
 gs
+bj
 gs
 gs
 gs
 gs
 gs
-gs
 al
 al
 al
@@ -27750,7 +28137,7 @@ al
 al
 al
 al
-CY
+YP
 gs
 gs
 gs
@@ -27802,7 +28189,7 @@ ZN
 ZN
 ZN
 ZN
-ZN
+PE
 ZN
 ZW
 ZW
@@ -28022,7 +28409,7 @@ gs
 gs
 gs
 ZN
-ZN
+PE
 ZN
 ZW
 ZW
@@ -28064,7 +28451,7 @@ ZK
 ZK
 ZK
 Rq
-ZL
+RH
 ZL
 ZL
 ZL
@@ -28268,14 +28655,14 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 MF
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 ZN
@@ -28310,7 +28697,7 @@ PO
 ZL
 ZL
 ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -28335,7 +28722,7 @@ ZK
 ZL
 ZL
 ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -28346,11 +28733,11 @@ dK
 Yt
 uC
 pG
-dK
+Qx
 dK
 WW
 kN
-qr
+Vz
 qr
 uK
 Lb
@@ -28495,23 +28882,23 @@ aI
 ah
 al
 al
-gs
-gs
-gs
-cb
+bj
 gs
 gs
 cb
 gs
 gs
+Dw
+gs
+gs
+bj
+gs
+cb
+bj
 gs
 gs
 cb
-gs
-gs
-gs
-cb
-gs
+bj
 al
 al
 al
@@ -28519,7 +28906,7 @@ gs
 Ak
 CY
 CY
-gs
+bj
 gs
 gs
 gs
@@ -28570,7 +28957,7 @@ ZL
 ZL
 jG
 ZL
-ZL
+RH
 Ta
 Ta
 Ta
@@ -28595,12 +28982,12 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 ZK
 YZ
 jm
 dK
-dK
+Qx
 WB
 EW
 wm
@@ -28755,7 +29142,7 @@ al
 al
 gs
 gs
-gs
+bj
 gs
 gs
 al
@@ -28770,7 +29157,7 @@ gs
 gs
 cb
 gs
-gs
+bj
 gs
 gs
 iM
@@ -28779,14 +29166,14 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 cb
 gs
 gs
 gs
 gs
-gs
+bj
 cb
 gs
 gs
@@ -28821,7 +29208,7 @@ QO
 qs
 US
 PO
-dt
+oM
 ZL
 ZL
 ZL
@@ -28838,7 +29225,7 @@ ZK
 RA
 jw
 Ta
-ZL
+RH
 ZL
 ZK
 ZK
@@ -28847,7 +29234,7 @@ ZK
 ZK
 ZL
 ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -29023,7 +29410,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 gs
@@ -29040,6 +29427,7 @@ gs
 gs
 gs
 gs
+bj
 gs
 gs
 gs
@@ -29047,11 +29435,10 @@ gs
 gs
 gs
 gs
-gs
-gs
+bj
 ZN
 ZN
-ZN
+PE
 ZN
 gy
 ZN
@@ -29118,7 +29505,7 @@ jK
 jk
 NP
 wK
-dK
+Qx
 zO
 YZ
 Zd
@@ -29285,13 +29672,13 @@ gs
 gs
 gs
 CY
-CY
+YP
 al
 al
 al
 al
 gC
-Bf
+oa
 Bf
 Bf
 Bf
@@ -29302,7 +29689,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 al
@@ -29313,7 +29700,7 @@ ZN
 ZN
 ZN
 ZN
-ZN
+PE
 HM
 Ma
 Ma
@@ -29345,7 +29732,7 @@ SQ
 SQ
 SQ
 SQ
-SQ
+aA
 ZK
 ZK
 ZK
@@ -29365,7 +29752,7 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 HK
 Rq
 JX
@@ -29524,7 +29911,7 @@ ah
 al
 al
 al
-gs
+bj
 gs
 gs
 al
@@ -29598,17 +29985,17 @@ ZK
 GO
 RA
 SQ
-SQ
-SQ
-kn
-SQ
+aA
 SQ
 kn
+SQ
+SQ
+ar
 kn
 kn
 SQ
 NT
-RA
+Xs
 ZK
 ZK
 ZK
@@ -29627,7 +30014,7 @@ HK
 ZK
 YZ
 sf
-dK
+Qx
 dK
 WB
 Qy
@@ -29796,7 +30183,7 @@ al
 al
 al
 gs
-gs
+bj
 CY
 CY
 gC
@@ -29888,7 +30275,7 @@ dK
 dK
 lK
 JI
-dK
+Qx
 wK
 mB
 WB
@@ -30041,7 +30428,7 @@ al
 al
 gs
 gs
-gs
+bj
 al
 al
 al
@@ -30070,7 +30457,7 @@ YO
 gC
 al
 gs
-gs
+bj
 gs
 gs
 gs
@@ -30086,11 +30473,11 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 ZL
 Rq
 Rq
-ZL
+RH
 ZK
 ZK
 ZK
@@ -30108,20 +30495,20 @@ Mw
 ZL
 ZL
 ZL
-zm
+Yx
 Ta
 RA
 SQ
 SQ
 kn
-kn
+ar
 SQ
 AG
 jw
 Mh
+ar
 kn
-kn
-SQ
+aA
 Bn
 ZK
 ZK
@@ -30131,11 +30518,11 @@ ZK
 ZL
 Rq
 Rq
+RH
 ZL
 ZL
 ZL
-ZL
-ZL
+RH
 ZL
 ZK
 ZK
@@ -30330,7 +30717,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 al
@@ -30339,7 +30726,7 @@ ZK
 Lm
 ZL
 ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -30355,7 +30742,7 @@ ZK
 ZK
 ZK
 ZK
-ZL
+RH
 ZL
 ZL
 ZL
@@ -30566,14 +30953,14 @@ al
 al
 al
 al
-gs
+bj
 CY
 CY
 al
 gC
 IX
 JV
-JV
+DQ
 ND
 zP
 zP
@@ -30590,7 +30977,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 ZL
 ZL
 ZL
@@ -30607,7 +30994,7 @@ Rq
 ZL
 ZL
 ZL
-ZL
+RH
 ZK
 ZK
 ZK
@@ -30626,7 +31013,7 @@ RA
 RA
 GO
 hT
-SQ
+aA
 kn
 SQ
 SQ
@@ -30647,12 +31034,12 @@ ZL
 ZL
 Lm
 ZL
-ZL
+RH
 OK
 ZL
 ZL
 ZL
-ZL
+RH
 ZK
 ZK
 YZ
@@ -30850,7 +31237,7 @@ gs
 gs
 ZL
 ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -30860,7 +31247,7 @@ ZK
 ZL
 ZL
 ZL
-Rq
+ax
 ZL
 ZL
 Lm
@@ -30890,7 +31277,7 @@ SQ
 RA
 jw
 SQ
-kn
+ar
 SQ
 SQ
 RA
@@ -30913,11 +31300,11 @@ ZL
 ZL
 ZK
 YZ
-kN
+SK
 kN
 WW
 gD
-dK
+Qx
 Lu
 YZ
 Zd
@@ -31068,7 +31455,7 @@ al
 al
 al
 al
-gs
+bj
 gs
 gs
 al
@@ -31090,7 +31477,7 @@ NQ
 JV
 vV
 zh
-Aj
+Zp
 Aj
 Aj
 Aj
@@ -31115,7 +31502,7 @@ ZK
 ZK
 ZK
 ZK
-Lm
+PK
 ZL
 Rq
 ZL
@@ -31125,7 +31512,7 @@ ZL
 ZL
 uh
 ZL
-ZL
+RH
 ZL
 ZL
 ZK
@@ -31142,32 +31529,32 @@ ZK
 GO
 Ei
 SQ
-SQ
+aA
 SQ
 AG
-NT
+xb
 SQ
 SQ
 jd
-RA
+Xs
 RA
 jG
-Lm
+PK
 ZL
 Ru
 ZL
 ZL
 ZK
 ZK
+RH
 ZL
 ZL
 ZL
+RH
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
+RH
 ZK
 YZ
 Pr
@@ -31336,14 +31723,14 @@ al
 al
 al
 al
-gs
+bj
 gs
 CY
-CY
+YP
 al
 gC
 NF
-NQ
+QZ
 JV
 Sb
 zP
@@ -31352,18 +31739,18 @@ vf
 aU
 aU
 aU
-Ww
+zW
 Ym
 yw
 Or
 ja
 nE
-gs
+bj
 gs
 gs
 gs
 ZL
-ZL
+RH
 ZL
 ZL
 ZK
@@ -31379,7 +31766,7 @@ Rq
 ZL
 ZL
 uh
-ZL
+RH
 Ru
 ZL
 ZK
@@ -31612,7 +31999,7 @@ kK
 Aj
 JP
 qI
-rX
+xL
 om
 yw
 al
@@ -31843,7 +32230,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 al
 aL
 al
@@ -31859,7 +32246,7 @@ jS
 JV
 NQ
 zJ
-zJ
+SD
 KU
 Nf
 Nf
@@ -31890,7 +32277,7 @@ ZK
 ZK
 Rq
 xG
-Nj
+Sn
 ZL
 ZL
 ZK
@@ -31910,7 +32297,7 @@ gq
 fw
 aY
 aY
-aY
+HF
 KA
 fw
 SQ
@@ -31937,7 +32324,7 @@ ZL
 ZL
 ZK
 ZL
-ZL
+RH
 ZL
 ZL
 Zg
@@ -32098,7 +32485,7 @@ bj
 al
 cb
 gs
-gs
+bj
 cb
 gs
 gs
@@ -32106,7 +32493,7 @@ hN
 gs
 cb
 gs
-gs
+bj
 fx
 gs
 cb
@@ -32119,7 +32506,7 @@ tr
 Ux
 zP
 Aj
-Aj
+Zp
 Aj
 Ww
 Aj
@@ -32134,7 +32521,7 @@ al
 al
 gs
 ZL
-ZL
+RH
 ZL
 ZK
 ZK
@@ -32160,7 +32547,7 @@ bE
 bJ
 bJ
 mI
-mI
+GC
 rv
 mI
 mI
@@ -32180,10 +32567,10 @@ Al
 AR
 TC
 LB
+VR
 JJ
 JJ
-JJ
-JJ
+VR
 LB
 Al
 Lm
@@ -32197,7 +32584,7 @@ ZK
 ZL
 ZL
 ZL
-Zg
+Zb
 Zg
 Zd
 Zd
@@ -32358,7 +32745,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 hN
 gs
 gs
@@ -32366,7 +32753,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 gC
@@ -32388,7 +32775,7 @@ om
 yw
 al
 al
-gs
+bj
 gs
 ZL
 ZL
@@ -32408,12 +32795,12 @@ AY
 ZL
 ZL
 ZL
-ZL
+RH
 MW
 fw
 ev
 aY
-aY
+HF
 ds
 fw
 qz
@@ -32443,10 +32830,10 @@ JJ
 JJ
 Au
 Al
+RH
 ZL
 ZL
-ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -32609,7 +32996,7 @@ al
 gs
 gg
 gs
-gs
+bj
 gs
 bL
 Et
@@ -32618,7 +33005,7 @@ gs
 gs
 hN
 gs
-gs
+bj
 gs
 gs
 gs
@@ -32656,14 +33043,14 @@ KJ
 KJ
 KJ
 KJ
-ZL
+RH
 ZL
 Rq
 ZL
 ZL
 ZL
 ZL
-ZL
+LT
 ZL
 ZL
 ZK
@@ -32677,10 +33064,10 @@ eh
 aY
 eP
 aY
-aY
+HF
 fw
 TM
-aY
+HF
 aY
 KA
 fw
@@ -32893,7 +33280,7 @@ Aj
 DT
 Im
 Im
-Aj
+Zp
 Nf
 Aj
 yw
@@ -32917,7 +33304,7 @@ ZL
 ZL
 Rq
 ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -32926,7 +33313,7 @@ ZL
 ZL
 fw
 fw
-pl
+sC
 aY
 fw
 fw
@@ -32943,16 +33330,16 @@ fw
 fw
 SQ
 SQ
-SQ
+aA
 jw
 Hj
+ax
 Rq
 Rq
+ax
 Rq
-Rq
-Rq
 ZL
-ZL
+RH
 ZL
 ZK
 ZK
@@ -32963,11 +33350,11 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 ZK
 ZK
 ZK
-ZL
+RH
 Zg
 Zg
 Zg
@@ -33124,7 +33511,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 bL
 gs
@@ -33139,7 +33526,7 @@ yw
 yw
 al
 al
-gs
+bj
 gs
 al
 yw
@@ -33154,22 +33541,22 @@ Aj
 Nf
 Ww
 qI
-rX
+xL
 om
 nE
 gs
 gs
 gs
-gs
+bj
 MW
 ZK
 ZL
 ZL
 ZL
+RH
 ZL
 ZL
-ZL
-ZL
+RH
 ZL
 ZL
 Rq
@@ -33211,7 +33598,7 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 ZK
 ZK
 ZL
@@ -33401,7 +33788,7 @@ gs
 RP
 yw
 ja
-PB
+yT
 yw
 Tb
 Aj
@@ -33433,26 +33820,26 @@ qV
 ZL
 ZL
 Lm
-ZL
+RH
 Rq
 Rq
-VX
+zu
 VX
 yV
 Nn
 xc
 pl
+HF
 aY
 aY
-aY
-yf
+cE
 fK
 aY
-aY
+HF
 aY
 aY
 yf
-aY
+HF
 pl
 nO
 kn
@@ -33472,7 +33859,7 @@ ZL
 ZL
 Ru
 ZL
-ZL
+RH
 ZL
 ZK
 ZK
@@ -33484,7 +33871,7 @@ ZK
 ZK
 Zd
 Zd
-Zg
+Zb
 Zg
 Zg
 Zd
@@ -33642,20 +34029,20 @@ gs
 gs
 gs
 cb
-gs
+bj
 gs
 aL
 al
 yw
 RJ
-iV
+qt
 RJ
 yw
 al
 al
 gs
 gs
-gs
+bj
 gb
 um
 rX
@@ -33664,7 +34051,7 @@ Ww
 Aj
 Aj
 Aj
-Aj
+Zp
 ZU
 nV
 yw
@@ -33672,7 +34059,7 @@ al
 al
 al
 gs
-gs
+bj
 gs
 gs
 ZK
@@ -33718,10 +34105,10 @@ Bn
 Bw
 zm
 ZL
-ZL
+RH
 ZL
 Lm
-ZL
+RH
 ZL
 ZL
 ZL
@@ -33940,10 +34327,10 @@ ZK
 Kx
 Ka
 SP
+RH
 ZL
 ZL
-ZL
-Rq
+ax
 ZL
 ZL
 Lm
@@ -33964,7 +34351,7 @@ fK
 aY
 aY
 aY
-aY
+HF
 aY
 JS
 pl
@@ -33980,11 +34367,11 @@ ZL
 ZL
 ZL
 ZL
+RH
 ZL
 ZL
 ZL
-ZL
-ZL
+RH
 Lm
 ZL
 ZL
@@ -34184,7 +34571,7 @@ yw
 zC
 AQ
 yw
-gs
+bj
 gs
 gs
 gs
@@ -34226,7 +34613,7 @@ iS
 gF
 aY
 nO
-SQ
+aA
 SQ
 SQ
 QH
@@ -34413,7 +34800,7 @@ al
 gs
 gs
 gs
-gs
+bj
 gs
 al
 al
@@ -34429,11 +34816,11 @@ gs
 gs
 gs
 Pj
-hH
+KD
 hH
 Pj
 yd
-yd
+pC
 yd
 yd
 zb
@@ -34460,7 +34847,7 @@ ZL
 Rq
 ZL
 Nj
-ZL
+RH
 ZL
 ZL
 ZK
@@ -34473,10 +34860,10 @@ aY
 fw
 fw
 aY
-aY
+HF
 BC
 Qv
-aY
+HF
 fw
 fw
 fw
@@ -34487,20 +34874,20 @@ SQ
 SQ
 SQ
 QH
+RH
 ZL
 ZL
 ZL
-ZL
-ZL
+RH
 ZL
 dt
 ZL
 ZL
-ZL
+RH
 ZK
 ZL
 ZL
-ZL
+RH
 ZK
 ZK
 ZK
@@ -34677,10 +35064,10 @@ gs
 yw
 Ca
 Sh
+Yr
 in
 in
-in
-gs
+bj
 gs
 cb
 gs
@@ -34696,12 +35083,12 @@ kX
 UE
 dX
 fu
-hH
+KD
 UD
 gs
 cb
 gs
-cb
+Dw
 al
 ZK
 ZK
@@ -35184,7 +35571,7 @@ al
 al
 gs
 gs
-gs
+bj
 gs
 gs
 al
@@ -35229,11 +35616,11 @@ ZL
 ZL
 ZL
 Rq
-ZL
+RH
 ZL
 ZL
 Ko
-ZL
+RH
 ZL
 ZK
 ZK
@@ -35241,14 +35628,14 @@ fw
 bo
 hw
 mI
-mI
+GC
 mI
 mI
 mI
 nA
 Om
 aY
-aY
+HF
 aY
 aY
 up
@@ -35260,7 +35647,7 @@ GO
 jw
 Co
 ZL
-ZL
+RH
 GO
 GO
 ZK
@@ -35270,7 +35657,7 @@ ZK
 ZK
 ZK
 Ru
-ZL
+RH
 Ru
 ZK
 ZL
@@ -35454,7 +35841,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 nE
 Db
 nN
@@ -35482,7 +35869,7 @@ ZK
 ZK
 ZL
 ZL
-ZL
+RH
 ZL
 ZL
 Rq
@@ -35501,7 +35888,7 @@ Qn
 bo
 aY
 gq
-aY
+HF
 aY
 aY
 gq
@@ -35700,7 +36087,7 @@ gs
 cb
 gs
 cb
-gs
+bj
 al
 yw
 yw
@@ -35709,26 +36096,26 @@ yw
 yw
 gs
 gs
-gs
+bj
 gs
 al
 yw
 Me
-PB
+yT
 YM
 Dj
-eX
+ie
 eX
 eX
 kP
 eX
 lL
 Ig
-PB
+yT
 ZC
 yw
 al
-gs
+bj
 gs
 gs
 ZK
@@ -35770,7 +36157,7 @@ fw
 fw
 ZK
 GO
-kn
+ar
 NT
 SQ
 Co
@@ -35963,7 +36350,7 @@ al
 al
 al
 al
-gs
+bj
 gs
 gs
 gs
@@ -35978,7 +36365,7 @@ eX
 Jy
 Ny
 kT
-eX
+ie
 iO
 yw
 yw
@@ -35993,7 +36380,7 @@ ZK
 Rq
 Rq
 Rq
-Rq
+ax
 Rq
 Rq
 Rq
@@ -36004,7 +36391,7 @@ ZL
 ZL
 Lm
 ZL
-ZL
+RH
 ZL
 ZL
 ZK
@@ -36036,7 +36423,7 @@ HA
 ZL
 ZL
 ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -36044,10 +36431,10 @@ ZL
 ZL
 VG
 ZL
+RH
 ZL
 ZL
-ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -36211,7 +36598,7 @@ al
 al
 al
 al
-gs
+bj
 gs
 gs
 gs
@@ -36256,7 +36643,7 @@ ZL
 ZL
 ZL
 Lm
-Rq
+ax
 ZL
 MV
 ZL
@@ -36297,7 +36684,7 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 Lm
 Rq
 ZL
@@ -36481,11 +36868,11 @@ gs
 gs
 gs
 gs
-gs
+bj
 al
 yw
 Me
-PB
+yT
 YM
 eX
 lb
@@ -36501,7 +36888,7 @@ gC
 gC
 gC
 gs
-gs
+bj
 ZL
 ZL
 Rq
@@ -36547,7 +36934,7 @@ SQ
 RA
 RA
 xa
-wl
+jl
 Ta
 ZL
 Rq
@@ -36729,7 +37116,7 @@ al
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 gs
@@ -36744,7 +37131,7 @@ yw
 yw
 yw
 yw
-eX
+ie
 lb
 Ba
 tU
@@ -36762,13 +37149,13 @@ gs
 ZL
 ZL
 Rq
-ZL
+RH
 ZK
 ZK
 ZK
 ZK
 ZK
-ZL
+RH
 ZL
 ZK
 jH
@@ -36791,14 +37178,14 @@ ZK
 ZK
 ZK
 ZK
-ZL
+RH
 ZL
 Lm
 ZL
-ZL
+RH
 Ru
 SQ
-SQ
+aA
 NT
 Bn
 NT
@@ -37065,14 +37452,14 @@ jF
 Ta
 ZL
 ZL
-ZL
+RH
 ZL
 VG
 ZL
 ZL
 ZK
 ZL
-ZL
+RH
 ZL
 ZL
 ZK
@@ -37248,7 +37635,7 @@ gs
 cb
 gs
 cb
-gs
+bj
 gs
 gs
 al
@@ -37263,7 +37650,7 @@ Dj
 eX
 eX
 eX
-eX
+ie
 iO
 yw
 oz
@@ -37316,7 +37703,7 @@ kn
 kn
 SQ
 SQ
-SQ
+aA
 wl
 xa
 jI
@@ -37531,7 +37918,7 @@ gC
 al
 al
 ZL
-ZL
+RH
 Rq
 ZK
 ZK
@@ -37756,11 +38143,11 @@ al
 al
 al
 al
+bj
 gs
 gs
 gs
-gs
-gs
+bj
 al
 al
 al
@@ -37822,7 +38209,7 @@ ZL
 JM
 Rq
 ZL
-ZL
+RH
 ZL
 ZK
 GO
@@ -37832,7 +38219,7 @@ GO
 Hm
 SQ
 RA
-RA
+Xs
 Ta
 sK
 GO
@@ -38074,7 +38461,7 @@ TO
 TO
 US
 PO
-ZL
+RH
 Lm
 ZL
 Rq
@@ -38272,7 +38659,7 @@ al
 al
 gs
 gs
-gs
+bj
 gs
 gs
 gs
@@ -38300,11 +38687,11 @@ Ow
 HT
 gC
 al
-gs
+bj
 ZL
 ZL
 Rq
-ZL
+RH
 ZK
 jH
 Fi
@@ -38537,17 +38924,17 @@ gs
 al
 al
 gC
+jz
 qZ
 qZ
-qZ
-qZ
+jz
 VH
 VA
 LE
 eX
 Dj
 eX
-eX
+ie
 eX
 eD
 yw
@@ -38594,7 +38981,7 @@ Rq
 Rq
 ZL
 ZL
-ZL
+RH
 ZL
 ZK
 ZK
@@ -38813,7 +39200,7 @@ ty
 gC
 al
 al
-gs
+bj
 gs
 ZL
 ZL
@@ -38861,7 +39248,7 @@ ZK
 ZK
 ZL
 ZL
-Nj
+Sn
 ZK
 ZK
 ZK
@@ -39043,10 +39430,10 @@ al
 al
 al
 al
+bj
 gs
 gs
-gs
-bW
+nY
 gs
 al
 al
@@ -39060,7 +39447,7 @@ yw
 LE
 wA
 wA
-LE
+fL
 wA
 wA
 LE
@@ -39105,7 +39492,7 @@ PO
 ZL
 ZL
 Rq
-ZL
+RH
 ZL
 ZL
 zj
@@ -39331,7 +39718,7 @@ gs
 gs
 ZL
 ZL
-ZL
+RH
 jH
 wp
 Dr
@@ -39360,7 +39747,7 @@ TO
 US
 PO
 ZL
-Rq
+ax
 Rq
 ZL
 ZL
@@ -39585,7 +39972,7 @@ gC
 al
 CY
 BX
-gs
+bj
 Lm
 ZL
 ZL
@@ -39623,7 +40010,7 @@ zj
 ZL
 ZL
 ZL
-ZL
+RH
 ZK
 ZK
 ZK
@@ -39638,7 +40025,7 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 ZK
 ZL
 ZL
@@ -39815,7 +40202,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gA
 gs
@@ -39831,7 +40218,7 @@ yw
 yw
 yw
 bs
-tL
+yn
 qp
 yw
 yw
@@ -39887,7 +40274,7 @@ ZK
 ZK
 ZK
 ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -40069,18 +40456,18 @@ al
 al
 gs
 gs
+bj
 gs
 gs
 gs
 gs
 gs
 gs
+bj
 gs
 gs
 gs
-gs
-gs
-gs
+bj
 al
 al
 al
@@ -40147,10 +40534,10 @@ ZL
 ZL
 ZL
 ZL
+RH
 ZL
 ZL
-ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -40355,7 +40742,7 @@ CY
 gs
 gs
 CY
-gs
+bj
 gs
 ZL
 Dg
@@ -40391,7 +40778,7 @@ ZK
 Rq
 ZL
 ZL
-ZL
+RH
 ZK
 ZK
 ZK
@@ -40411,10 +40798,10 @@ ZL
 ZL
 ZL
 ZL
+RH
 ZL
 ZL
-ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -40581,12 +40968,12 @@ al
 al
 al
 gs
+bj
 gs
 gs
 gs
 gs
-gs
-gs
+bj
 al
 al
 gs
@@ -40604,11 +40991,11 @@ gs
 gs
 CY
 CY
-CY
+YP
 CY
 CY
 gs
-gs
+bj
 gs
 gs
 CY
@@ -40627,7 +41014,7 @@ ZK
 ZL
 ZL
 ZL
-ZL
+RH
 ZL
 ZK
 ZK
@@ -40841,24 +41228,24 @@ gs
 gs
 gs
 gs
-gs
+bj
 al
 al
 al
 al
 al
 gs
+bj
+gs
+gs
+bj
 gs
 gs
 gs
 gs
 gs
 gs
-gs
-gs
-gs
-gs
-gs
+bj
 gs
 gs
 gs
@@ -40880,7 +41267,7 @@ Dg
 ZK
 ZK
 Lm
-ZL
+RH
 ZL
 ZL
 ZL
@@ -40914,6 +41301,7 @@ ZK
 ZK
 ZL
 ZL
+RH
 ZL
 ZL
 ZL
@@ -40921,8 +41309,7 @@ ZL
 ZL
 ZL
 ZL
-ZL
-Gz
+qk
 ZL
 ZL
 ZL
@@ -41112,14 +41499,14 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 gs
 cb
 gs
 gs
-gs
+bj
 cb
 gs
 gs
@@ -41159,7 +41546,7 @@ US
 ZK
 ZK
 ZL
-Rq
+ax
 ZL
 ZK
 ZK
@@ -41175,18 +41562,18 @@ ZL
 ZL
 ZL
 Gz
-ZL
+RH
 ZL
 ZK
-ZK
-ZL
-ZL
 ZK
 ZL
 ZL
+ZK
 ZL
 ZL
 ZL
+ZL
+RH
 ZL
 ZL
 Zg
@@ -41353,7 +41740,7 @@ al
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 al
@@ -41382,7 +41769,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 ZK
@@ -41391,7 +41778,7 @@ Dg
 Dg
 Dg
 Dg
-ZL
+RH
 ZL
 ZL
 ZL
@@ -41439,7 +41826,7 @@ ZK
 ZK
 ZK
 ZK
-ZL
+RH
 ZL
 ZL
 ZL
@@ -41607,7 +41994,7 @@ al
 al
 al
 al
-gs
+bj
 cY
 gs
 gs
@@ -41624,7 +42011,7 @@ al
 gs
 gs
 gs
-gs
+bj
 gs
 gA
 pW
@@ -41636,7 +42023,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 gs
 gs
 gs
@@ -41887,7 +42274,7 @@ gs
 gs
 gs
 gs
-gs
+bj
 pW
 gx
 gs
@@ -41922,7 +42309,7 @@ ZK
 Dt
 TO
 PO
-ZL
+RH
 ZL
 ZL
 ZL
@@ -41955,7 +42342,7 @@ ZK
 ZK
 ZL
 ZL
-ZL
+RH
 ZL
 ZL
 ZL
@@ -42157,6 +42544,7 @@ OD
 OD
 OD
 ZL
+RH
 ZL
 ZL
 ZL
@@ -42164,8 +42552,7 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
+RH
 ZK
 ZK
 ZK
@@ -42183,7 +42570,7 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 ZL
 ZL
 qc
@@ -42728,7 +43115,7 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 ZL
 ZL
 Zb
@@ -42931,14 +43318,14 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 ZL
 ZK
 ZK
 ZK
 ZL
 ZL
-ZL
+RH
 oT
 Ry
 Gs
@@ -42981,7 +43368,7 @@ ZK
 ZK
 ZL
 Lm
-ZL
+RH
 ZL
 ZL
 ZL
@@ -43209,10 +43596,10 @@ Mw
 Ta
 ZL
 ZL
+RH
 ZL
 ZL
-ZL
-ZL
+RH
 ZK
 PQ
 ZL
@@ -43443,7 +43830,7 @@ sa
 sa
 ZK
 ZK
-ZL
+RH
 ZL
 ZL
 ZL
@@ -43471,7 +43858,7 @@ ZL
 ZK
 ZK
 ZK
-Rq
+ax
 ZL
 ZL
 ZK
@@ -43497,7 +43884,7 @@ ZL
 ZL
 ZL
 ZL
-ZL
+RH
 ZL
 ZK
 ZK
@@ -43529,9 +43916,9 @@ Zd
 WS
 Zd
 Zd
-Zb
-Zg
-Zg
+ed
+oA
+oA
 Zd
 Zd
 Zd
@@ -43961,14 +44348,14 @@ ZK
 fi
 ZL
 Lm
-ZL
+RH
 ZK
 ZK
 ZK
 ZK
 ZL
 ZL
-ZL
+RH
 ZL
 Ry
 GZ
@@ -44008,7 +44395,7 @@ ZK
 ZL
 ZL
 ZL
-ZL
+RH
 ZK
 ZK
 ZK
@@ -44244,7 +44631,7 @@ ZK
 ZL
 Rq
 ZL
-ZL
+RH
 ZK
 ZK
 ZK
@@ -44262,7 +44649,7 @@ ZK
 ZK
 ZK
 ZK
-ZL
+RH
 ZL
 ZL
 JZ
@@ -44514,7 +44901,7 @@ RA
 RA
 RA
 RA
-RA
+Xs
 RA
 ZK
 ZK
@@ -44778,7 +45165,7 @@ Ta
 ZL
 ZL
 ZL
-ZL
+RH
 Kk
 RA
 Am
@@ -45032,7 +45419,7 @@ RA
 Ta
 Ta
 ZL
-ZL
+RH
 ZL
 Ta
 ZL
@@ -45269,7 +45656,7 @@ mt
 dn
 yo
 ZO
-Xd
+IH
 BK
 wq
 Xd
@@ -45283,7 +45670,7 @@ ZK
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -45530,7 +45917,7 @@ Pv
 Pv
 Pv
 Xd
-Pv
+LC
 EB
 ZK
 ZK
@@ -45587,9 +45974,9 @@ Zd
 Zd
 Zd
 Zd
-Zg
-Zb
-Zg
+oA
+ed
+oA
 Zd
 Zd
 QA
@@ -45778,13 +46165,13 @@ EB
 EB
 Vc
 Sc
-Vj
+uu
 UY
 rG
 ji
 Vc
 EB
-Pv
+LC
 Pv
 zs
 Pv
@@ -45800,7 +46187,7 @@ Pv
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 EB
 EB
@@ -45836,7 +46223,7 @@ WF
 Zg
 Zg
 ft
-Zb
+ed
 WF
 Zg
 Zd
@@ -46037,7 +46424,7 @@ Vc
 bZ
 Vj
 UY
-Zu
+Bu
 vM
 Vc
 EB
@@ -46051,7 +46438,7 @@ EB
 EB
 EB
 EB
-Pv
+LC
 Pv
 Pv
 Pv
@@ -46076,7 +46463,7 @@ Zd
 Zd
 Zd
 Zd
-Zg
+Zb
 Zg
 Zg
 VJ
@@ -46093,7 +46480,7 @@ Zd
 Zd
 ft
 ft
-Zg
+oA
 Zg
 Zb
 Zg
@@ -46290,7 +46677,7 @@ Pv
 wq
 oV
 rG
-Zu
+Bu
 Zu
 Zu
 Zu
@@ -46319,7 +46706,7 @@ Pv
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 Lk
 HN
@@ -46351,9 +46738,9 @@ Zd
 WS
 Zd
 Zd
-Zg
-Zg
-Xj
+oA
+oA
+hF
 Zd
 WF
 Zg
@@ -46595,7 +46982,7 @@ Zg
 Zg
 Zg
 Zg
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -46807,7 +47194,7 @@ Vc
 Vc
 Vc
 UY
-Vj
+uu
 qR
 Sc
 Vc
@@ -46815,7 +47202,7 @@ EB
 EB
 pX
 Xd
-Pv
+LC
 Pv
 Pv
 pX
@@ -46826,7 +47213,7 @@ EB
 EB
 EB
 Pv
-Pv
+LC
 Pv
 Pv
 EB
@@ -46845,7 +47232,7 @@ Zd
 Zd
 Zd
 Zd
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -47069,12 +47456,12 @@ Vj
 Il
 Vc
 EB
-pX
+Af
 Pv
 Xd
 Pv
 Pv
-Pv
+LC
 Pv
 pX
 EB
@@ -47087,11 +47474,11 @@ Pv
 Pv
 Pv
 Pv
+LC
 Pv
 Pv
 Pv
-Pv
-Pv
+LC
 Pv
 HN
 NN
@@ -47322,14 +47709,14 @@ Pv
 WG
 Sm
 sr
-Vj
+uu
 el
 Vc
 EB
 Pv
 Pv
 Xd
-Pv
+LC
 Pv
 Pv
 Pv
@@ -47574,7 +47961,7 @@ Pv
 Pv
 Xd
 Pv
-Pv
+LC
 Pv
 WG
 Mt
@@ -47598,7 +47985,7 @@ EB
 EB
 Pv
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -47616,7 +48003,7 @@ ZS
 wj
 wj
 wj
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -47841,14 +48228,14 @@ bz
 Vc
 Pv
 Pv
-Pv
+LC
 PL
 PL
 PL
 PL
 PL
 uR
-Pv
+LC
 EB
 EB
 EB
@@ -47860,13 +48247,13 @@ EB
 EB
 EB
 EB
-wj
+RN
 wj
 aV
 wj
 wj
 wj
-wj
+RN
 wj
 wj
 wj
@@ -47879,7 +48266,7 @@ Xo
 Xo
 Zg
 Zg
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -48376,7 +48763,7 @@ pX
 Pv
 wj
 wj
-wj
+RN
 wj
 wj
 Lo
@@ -48600,7 +48987,7 @@ EB
 EB
 EB
 Pv
-Pv
+LC
 Pv
 Xd
 Pv
@@ -48611,7 +48998,7 @@ EB
 EB
 EB
 Pv
-Pv
+LC
 Pv
 PL
 QN
@@ -48621,7 +49008,7 @@ PL
 pX
 Pv
 Pv
-pX
+Af
 Pv
 Pv
 Pv
@@ -48887,7 +49274,7 @@ Pv
 Pv
 Pv
 Pv
-Pv
+LC
 wj
 wj
 ZS
@@ -48918,7 +49305,7 @@ dr
 QS
 QS
 QS
-QT
+Zv
 Xo
 Xo
 QT
@@ -49112,13 +49499,13 @@ EB
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
 Xd
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -49139,10 +49526,10 @@ Pv
 Pv
 Pv
 Pv
+LC
 Pv
 Pv
-Pv
-Pv
+LC
 Pv
 Pv
 wj
@@ -49175,7 +49562,7 @@ dr
 QS
 Xo
 Xo
-Xo
+nM
 Bz
 Xo
 Xo
@@ -49378,10 +49765,10 @@ Pv
 Pv
 Pv
 Pv
+LC
 Pv
 Pv
-Pv
-Pv
+LC
 Pv
 EB
 EB
@@ -49389,7 +49776,7 @@ EB
 EB
 EB
 EB
-Pv
+LC
 Pv
 Pv
 Pv
@@ -49429,10 +49816,10 @@ QT
 Xo
 Xo
 Jz
-Xo
+nM
 Bz
 Xo
-QT
+Zv
 Xo
 SA
 SA
@@ -49650,7 +50037,7 @@ EB
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -49686,7 +50073,7 @@ Bz
 Xo
 Xo
 Jz
-Xo
+nM
 tB
 Xo
 QS
@@ -50142,14 +50529,14 @@ Pv
 Pv
 Pv
 Pv
+LC
 Pv
 Pv
 Pv
 Pv
+LC
 Pv
-Pv
-Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -50169,10 +50556,10 @@ Pv
 Pv
 Pv
 Si
-Pv
+LC
 Pv
 pX
-Pv
+LC
 ZS
 ZS
 mo
@@ -50659,28 +51046,28 @@ Pv
 Pv
 Pv
 Pv
+LC
 Pv
 Pv
+EB
+EB
+EB
+EB
 Pv
-EB
-EB
-EB
-EB
+Af
+Pv
+Pv
+LC
+Pv
 Pv
 pX
 Pv
-Pv
-Pv
-Pv
-Pv
-pX
-Pv
-Pv
+LC
 Pv
 pX
 EB
 EB
-Pv
+LC
 Pv
 Pv
 EB
@@ -50942,7 +51329,7 @@ WV
 Cr
 Cr
 EB
-Pv
+LC
 Pv
 ZS
 ZS
@@ -51170,7 +51557,7 @@ EB
 EB
 EB
 EB
-Pv
+LC
 Pv
 Pv
 Pv
@@ -51225,8 +51612,8 @@ Xo
 Xo
 jN
 Xo
-Xo
-Xo
+SA
+SA
 Xo
 Xo
 Sz
@@ -51441,9 +51828,9 @@ EB
 EB
 EB
 EB
+LC
 Pv
-Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -51482,8 +51869,8 @@ QS
 Xo
 Xo
 Xo
-Xo
-Xo
+SA
+SA
 Xo
 Xo
 Xo
@@ -51688,7 +52075,7 @@ Pv
 Pv
 Pv
 Pv
-Pv
+LC
 EB
 EB
 EB
@@ -51713,7 +52100,7 @@ uF
 Gw
 Cr
 EB
-Pv
+LC
 Pv
 wj
 wj
@@ -51974,7 +52361,7 @@ pX
 Pv
 wj
 wj
-wj
+RN
 Lo
 ZS
 ZS
@@ -52199,12 +52586,12 @@ EB
 EB
 EB
 EB
+LC
 Pv
 Pv
 Pv
 Pv
-Pv
-Pv
+LC
 EB
 EB
 EB
@@ -52229,7 +52616,7 @@ EB
 EB
 Pv
 Pv
-Pv
+LC
 Pv
 wj
 wj
@@ -52241,7 +52628,7 @@ QS
 QS
 QT
 Xo
-Xo
+Bz
 Xo
 QT
 QS
@@ -52471,7 +52858,7 @@ EB
 EB
 EB
 Pv
-Pv
+LC
 Pv
 EB
 Cr
@@ -52516,7 +52903,7 @@ Xo
 SO
 Xo
 Xo
-Xo
+Bz
 Xo
 Xo
 QS
@@ -52715,13 +53102,13 @@ EB
 EB
 EB
 EB
+LC
 Pv
 Pv
 Pv
 Pv
 Pv
-Pv
-Pv
+LC
 EB
 EB
 EB
@@ -52748,11 +53135,11 @@ Pv
 wj
 wj
 wj
-wj
+RN
 wj
 wj
 Xo
-Xo
+Bz
 Xo
 Xo
 Xo
@@ -52997,12 +53384,12 @@ SH
 fV
 Cr
 Pv
-Pv
+LC
 Pv
 EB
 EB
 Pv
-wj
+RN
 Lo
 wj
 wb
@@ -53232,7 +53619,7 @@ EB
 EB
 EB
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -53268,7 +53655,7 @@ wj
 QT
 Xo
 QT
-Xo
+Bz
 QS
 QS
 QS
@@ -53498,10 +53885,10 @@ EB
 EB
 EB
 EB
+LC
 Pv
 Pv
-Pv
-Pv
+LC
 Pv
 Pv
 dH
@@ -53520,7 +53907,7 @@ ZS
 ZS
 wj
 wj
-wj
+RN
 wj
 Xo
 Xo
@@ -53549,7 +53936,7 @@ Xo
 Xo
 Xo
 Xo
-Xo
+Bz
 QV
 aI
 aI
@@ -53749,7 +54136,7 @@ EB
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 EB
 EB
@@ -53760,7 +54147,7 @@ Pv
 Pv
 Pv
 Pv
-Pv
+LC
 dH
 ud
 CU
@@ -54020,7 +54407,7 @@ Pv
 Pv
 dH
 rS
-CU
+TZ
 CU
 fV
 Mn
@@ -54288,10 +54675,10 @@ EB
 EB
 Pv
 wj
+RN
 wj
 wj
-wj
-wj
+RN
 wj
 QS
 QS
@@ -54526,10 +54913,10 @@ EB
 Pv
 Pv
 Pv
+LC
 Pv
 Pv
-Pv
-Pv
+LC
 Pv
 EB
 Cr
@@ -54777,7 +55164,7 @@ EB
 EB
 EB
 EB
-Pv
+LC
 Pv
 Pv
 Pv
@@ -55037,7 +55424,7 @@ EB
 Pv
 pX
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -55057,7 +55444,7 @@ EB
 EB
 EB
 EB
-Pv
+LC
 wj
 ZS
 ZS
@@ -55298,7 +55685,7 @@ Pv
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 EB
 EB
@@ -55829,10 +56216,10 @@ EB
 pX
 Pv
 pX
-wj
+RN
 wj
 Mx
-wj
+RN
 wj
 ZS
 QS
@@ -56069,7 +56456,7 @@ EB
 EB
 EB
 EB
-Pv
+LC
 Pv
 Pv
 EB
@@ -56351,8 +56738,8 @@ wj
 kH
 Xo
 Xo
-Xo
-jN
+SA
+LQ
 Sr
 Xo
 Ev
@@ -56585,7 +56972,7 @@ EB
 EB
 EB
 Pv
-Pv
+LC
 Pv
 EB
 EB
@@ -56596,20 +56983,20 @@ Pv
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
 ZS
 ZS
 Lo
-wj
+RN
 wj
 kH
 Xo
 Xo
-Xo
-Xo
+SA
+SA
 QT
 Xo
 Xo
@@ -56844,13 +57231,13 @@ EB
 pX
 Pv
 Pv
-Pv
+LC
 Pv
 Pv
 pX
 Pv
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -57104,7 +57491,7 @@ Pv
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -57356,7 +57743,7 @@ EB
 EB
 EB
 EB
-Pv
+LC
 Pv
 Pv
 Pv
@@ -58165,7 +58552,7 @@ Xo
 Xo
 Xo
 SO
-Xo
+Bz
 Xo
 Xo
 Xo

--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -771,6 +771,10 @@
 	dir = 1
 	},
 /area/barren)
+"eh" = (
+/obj/effect/landmark/sensor_tower_patrol,
+/turf/open/floor/tile/dark2,
+/area/barren/engie/engine)
 "ei" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -3168,6 +3172,12 @@
 	dir = 4
 	},
 /area/barren/security)
+"qT" = (
+/obj/effect/landmark/sensor_tower_patrol,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/caves/south)
 "qU" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/tile/blue/whiteblue{
@@ -3435,6 +3445,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark2,
 /area/bigredv2/outside/general_offices)
+"sm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/sensor_tower_patrol,
+/turf/open/floor/grimy,
+/area/barren/civilian/workdorm)
 "sn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -8054,6 +8069,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/barren/medical/research)
 "Sh" = (
+/obj/effect/landmark/sensor_tower_patrol,
 /turf/open/floor/prison/sterilewhite,
 /area/barren/civilian)
 "Si" = (
@@ -8095,6 +8111,10 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/caves/southwest)
+"Sv" = (
+/obj/effect/landmark/sensor_tower_patrol,
+/turf/open/lavaland/catwalk,
+/area/bigredv2/outside/w)
 "Sw" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/lavaland/basalt{
@@ -18256,7 +18276,7 @@ Dt
 TO
 QJ
 Ke
-Ke
+Sv
 Ke
 xi
 Tq
@@ -32653,7 +32673,7 @@ aY
 aY
 bu
 fw
-aY
+eh
 aY
 eP
 aY
@@ -37604,7 +37624,7 @@ Zg
 Zg
 WF
 Zb
-Zg
+qT
 Zg
 ia
 Zd
@@ -54258,7 +54278,7 @@ Pv
 dH
 An
 yD
-CU
+sm
 CU
 Ci
 nw

--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -3527,7 +3527,9 @@
 	id = "TGMC_11";
 	name = "TGMC exit point 11"
 	},
-/turf/open/lavaland/basalt,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
 /area/bigredv2/outside/nw)
 "sP" = (
 /obj/effect/landmark/corpsespawner/doctor,
@@ -7807,9 +7809,6 @@
 /obj/structure/table/reinforced/prison,
 /turf/open/floor/mainship/black/full,
 /area/barren/security)
-"QR" = (
-/turf/open/lavaland/basalt,
-/area/bigredv2/outside/nw)
 "QS" = (
 /turf/closed/brock,
 /area/bigredv2/caves/southeast)
@@ -16144,8 +16143,8 @@ rK
 rK
 rK
 rK
-QR
-QR
+fM
+fM
 fM
 fM
 fM
@@ -16401,8 +16400,8 @@ rK
 rK
 rK
 sO
-QR
-QR
+fM
+fM
 fM
 fM
 rK
@@ -16657,9 +16656,9 @@ rK
 rK
 rK
 rK
-QR
 fM
-QR
+fM
+fM
 fM
 fM
 rK
@@ -16914,9 +16913,9 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 fM
 EI
 rK
@@ -17171,9 +17170,9 @@ rK
 rK
 rK
 rK
-QR
-QR
-QR
+fM
+fM
+fM
 fM
 fM
 fM
@@ -17429,8 +17428,8 @@ rK
 rK
 rK
 rK
-QR
-QR
+fM
+fM
 fM
 fM
 fM

--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -668,6 +668,7 @@
 "dB" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/paper,
+/obj/effect/landmark/weapon_spawn/tier2_weapon_spawn,
 /turf/open/floor/wood,
 /area/barren/security)
 "dC" = (
@@ -780,12 +781,7 @@
 /area/bigredv2/outside/n)
 "ea" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/pistol/g22,
-/obj/item/ammo_magazine/pistol/g22,
-/obj/item/ammo_magazine/pistol/g22,
-/obj/item/ammo_magazine/pistol/g22,
-/obj/item/ammo_magazine/pistol/g22,
-/obj/item/ammo_magazine/pistol/g22,
+/obj/effect/spawner/random/gun/sidearms,
 /turf/open/floor/tile/red/full,
 /area/barren/security)
 "eb" = (
@@ -926,6 +922,12 @@
 /obj/structure/sign/poster,
 /turf/open/floor,
 /area/barren/civilian)
+"eE" = (
+/obj/effect/spawner/random/trash,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/outside/e)
 "eF" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -1434,7 +1436,8 @@
 "gU" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Dormitories Bedroom"
+	name = "\improper Dormitories Bedroom";
+	locked = 1
 	},
 /turf/open/floor/plating/mainship,
 /area/bigredv2/outside/w)
@@ -1478,6 +1481,7 @@
 /area/bigredv2/caves/southwest)
 "hg" = (
 /obj/structure/bed/chair/sofa/right,
+/obj/effect/spawner/random/plushie/nospawnninetynine,
 /turf/open/floor/carpet{
 	icon_state = "carpet6-0"
 	},
@@ -1916,6 +1920,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/barren/security)
+"jv" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/pillbottle,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/barren/medical/chemistry)
 "jw" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -2929,9 +2940,7 @@
 /turf/open/floor/wood,
 /area/barren/cave/lz1)
 "oQ" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/pillbottles,
+/obj/machinery/vending/medical,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 10
 	},
@@ -3146,6 +3155,10 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/tile/dark,
 /area/barren/cave/lz2)
+"pZ" = (
+/obj/effect/landmark/corpsespawner/colonist/regular,
+/turf/open/floor/tile,
+/area/bigredv2/outside/w)
 "qa" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/prison/sterilewhite,
@@ -4163,6 +4176,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean/two,
 /area/barren/security)
+"vm" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/plushie/nospawnninetynine,
+/turf/open/floor/marking/delivery,
+/area/barren/misc/genstorage)
 "vn" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4229,6 +4247,7 @@
 /obj/item/storage/box/flashbangs,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/random/gun,
 /turf/open/floor/tile/red/full,
 /area/barren/security)
 "vK" = (
@@ -5229,7 +5248,13 @@
 /obj/structure/rack,
 /obj/item/weapon/gun/pistol/g22,
 /obj/item/weapon/gun/pistol/g22,
+/obj/item/ammo_magazine/pistol/g22,
 /obj/item/weapon/gun/pistol/g22,
+/obj/item/ammo_magazine/pistol/g22,
+/obj/item/ammo_magazine/pistol/g22,
+/obj/item/ammo_magazine/pistol/g22,
+/obj/item/ammo_magazine/pistol/g22,
+/obj/item/ammo_magazine/pistol/g22,
 /turf/open/floor/tile/red/full,
 /area/barren/security)
 "Bn" = (
@@ -6201,6 +6226,7 @@
 "Gi" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower,
+/obj/effect/landmark/weapon_spawn/tier3_weapon_spawn,
 /turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/outside/w)
 "Gj" = (
@@ -6537,6 +6563,7 @@
 /obj/item/clothing/suit/armor/vest,
 /obj/item/clothing/suit/armor/vest,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/ammo,
 /turf/open/floor/tile/red/full,
 /area/barren/security)
 "Id" = (
@@ -7048,6 +7075,7 @@
 /obj/structure/bed/chair/pew{
 	dir = 5
 	},
+/obj/effect/spawner/random/trash,
 /turf/open/lavaland/basalt{
 	baseturfs = /turf/open/lavaland/basalt
 	},
@@ -7200,6 +7228,7 @@
 /area/barren/cave/lz2)
 "Lu" = (
 /obj/structure/table/reinforced,
+/obj/item/storage/belt/lifesaver/full,
 /turf/open/floor/prison/sterilewhite,
 /area/barren/medical/research)
 "Lv" = (
@@ -7239,6 +7268,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/spawner/random/pillbottle,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 8
 	},
@@ -7480,10 +7510,10 @@
 /turf/open/floor/prison/sterilewhite,
 /area/barren/civilian)
 "Na" = (
-/obj/machinery/power/apc/drained{
+/obj/structure/cable,
+/obj/machinery/power/apc/high{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/carpet{
 	icon_state = "carpet7-0"
 	},
@@ -7608,6 +7638,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/bigredv2/caves/south)
+"NO" = (
+/obj/effect/landmark/weapon_spawn/tier1_weapon_spawn,
+/turf/open/floor/plating,
+/area/bigredv2/outside/c)
 "NP" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -9009,6 +9043,8 @@
 /obj/effect/decal/cleanable/cobweb{
 	dir = 4
 	},
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/beakers,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 1
 	},
@@ -22280,7 +22316,7 @@ ZW
 ZW
 ZW
 em
-FW
+pZ
 FW
 gN
 RZ
@@ -36685,7 +36721,7 @@ GO
 iH
 NT
 AG
-RA
+NO
 jj
 Ta
 Ta
@@ -39234,7 +39270,7 @@ Jl
 VC
 WJ
 Zw
-aD
+jv
 ss
 Jl
 ZK
@@ -45647,7 +45683,7 @@ rf
 rR
 Pv
 LC
-Pv
+eE
 Pv
 LC
 Pv
@@ -47978,7 +48014,7 @@ WG
 Mt
 YC
 Vj
-UY
+vm
 Vc
 Pv
 Pv

--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -5383,6 +5383,14 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/outside/c)
+"BV" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/lavaland/basalt{
+	baseturfs = /turf/open/lavaland/basalt
+	},
+/area/bigredv2/caves/south)
 "BW" = (
 /obj/structure/bed/chair/wood/wings,
 /turf/open/floor/wood,
@@ -9034,6 +9042,9 @@
 	baseturfs = /turf/open/lavaland/basalt
 	},
 /area/bigredv2/caves/south)
+"VK" = (
+/turf/open/space/basic,
+/area/bigredv2/outside/e)
 "VL" = (
 /turf/open/floor/plating/warning{
 	dir = 4
@@ -18447,7 +18458,7 @@ HQ
 HQ
 HQ
 Su
-YI
+QB
 HQ
 HQ
 HQ
@@ -19475,7 +19486,7 @@ Jv
 YI
 YI
 YI
-YI
+QB
 YI
 Jv
 YI
@@ -19743,7 +19754,7 @@ HQ
 HQ
 YI
 YI
-YI
+QB
 Dq
 Jv
 Sw
@@ -19997,7 +20008,7 @@ YI
 YI
 YI
 YI
-YI
+QB
 YI
 VF
 YI
@@ -20506,7 +20517,7 @@ HQ
 HQ
 HQ
 YI
-YI
+QB
 HQ
 HQ
 YI
@@ -20774,7 +20785,7 @@ YI
 YI
 Dq
 YI
-YI
+QB
 AH
 HQ
 HQ
@@ -21276,11 +21287,11 @@ HQ
 HQ
 HQ
 YI
-YI
+QB
 HQ
 HQ
 YI
-YI
+QB
 Su
 YI
 YI
@@ -25916,7 +25927,7 @@ YI
 HQ
 YI
 YI
-YI
+QB
 YI
 YI
 YI
@@ -32736,7 +32747,7 @@ aI
 aI
 ah
 al
-gs
+bj
 gs
 gs
 gs
@@ -32994,8 +33005,8 @@ aI
 ah
 al
 gs
-gg
 gs
+gg
 bj
 gs
 bL
@@ -34922,7 +34933,7 @@ Zg
 Zg
 Zg
 Zd
-Zg
+Zb
 Zg
 Zg
 WF
@@ -35699,7 +35710,7 @@ Zg
 Zg
 Zd
 Zd
-Zg
+Zb
 Zg
 Zd
 Zd
@@ -38004,7 +38015,7 @@ Zg
 Zq
 Zg
 Zg
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -38020,7 +38031,7 @@ Zd
 Zd
 Zd
 Zg
-Zg
+Zb
 Zd
 QA
 aI
@@ -38777,7 +38788,7 @@ Zg
 Zg
 Zg
 XB
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -39031,7 +39042,7 @@ Zg
 Zg
 Zg
 Zg
-Zg
+Zb
 Zg
 XB
 Zg
@@ -40833,7 +40844,7 @@ Zd
 Zd
 lz
 dG
-dG
+BV
 Lb
 XB
 XB
@@ -44161,7 +44172,7 @@ Zg
 Zd
 Zd
 Zd
-Zg
+Zb
 Zg
 Zg
 Zg
@@ -44864,7 +44875,7 @@ Mw
 Mw
 Ie
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -45123,11 +45134,11 @@ Ie
 Pv
 Pv
 Pv
+LC
 Pv
 Pv
 Pv
-Pv
-ZL
+RH
 ZL
 Ry
 Mw
@@ -45635,10 +45646,10 @@ rf
 rf
 rR
 Pv
+LC
 Pv
 Pv
-Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -45703,7 +45714,7 @@ Zg
 Zd
 Zd
 Zg
-Zg
+Zb
 sS
 HN
 HN
@@ -45899,7 +45910,7 @@ Pv
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 lt
 QO
@@ -46184,7 +46195,7 @@ ZK
 Pv
 hC
 Pv
-Pv
+VK
 Pv
 Pv
 LC
@@ -46406,7 +46417,7 @@ rf
 rf
 rR
 Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -46671,7 +46682,7 @@ pX
 Pv
 Pv
 Pv
-Pv
+LC
 Pv
 Pv
 wq
@@ -46922,9 +46933,9 @@ Hp
 pF
 Pv
 Pv
+LC
 Pv
-Pv
-Pv
+LC
 Pv
 Pv
 Pv
@@ -47503,7 +47514,7 @@ Zg
 WF
 Zg
 Zg
-Zg
+Zb
 Zd
 WS
 WS
@@ -47702,7 +47713,7 @@ EB
 Pv
 Pv
 Pv
-Xd
+IH
 Pv
 Pv
 Pv
@@ -49801,7 +49812,7 @@ Op
 QS
 QS
 QS
-Xo
+Bz
 Xo
 Xo
 Xo
@@ -53408,7 +53419,7 @@ Xo
 Xo
 Sz
 Xo
-Xo
+Bz
 QS
 QS
 QS
@@ -53926,7 +53937,7 @@ Xo
 QS
 QS
 Xo
-Xo
+Bz
 Xo
 uf
 Xo
@@ -56746,7 +56757,7 @@ Ev
 Xo
 Xo
 Xo
-Xo
+Bz
 Xo
 Xo
 Xo
@@ -58027,7 +58038,7 @@ Xo
 Xo
 Xo
 QT
-Xo
+Bz
 Xo
 Xo
 QT
@@ -58805,7 +58816,7 @@ Xo
 Xo
 Xo
 Xo
-Xo
+Bz
 Xo
 Xo
 Xo

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -636,6 +636,10 @@
 /turf/open/floor/prison/can_dig_xeno_tunnel()
 	return TRUE
 
+/turf/open/lavaland/basalt/can_dig_xeno_tunnel()
+	return TRUE
+
+
 
 
 


### PR DESCRIPTION
## About The Pull Request

Продолжаем работу на Барранквиллой, в этом пре:
1. Добавлена трава на большую часть карты (место возле лз, а также отдельные закрытые участки оставлены не тронутыми)
2. Добавлены башни для игры в режиме Захват Сенсоров
3. Лорд теперь может копать туннели по всей карте
4. Базовая клетка теперь базальт, а не лава, цветки Ржордана теперь не ломают пол (но их все равно лучше починить, конечно)
5. Немножечко рандомного лута
5.5 И немножечко лекарств в меде 

## Why It's Good For The Game

Продолжаем поддерживать жизнь в мертвой карте

## Changelog
:cl:
qol: Preweed everywhere (almost) 
balance: Kosher Loot
fix: HiveLord can dig tunnels
fix: HiveMind can't create lavaturf
fix: Sensor Capture now playable 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
