### PR TITLE
Fix: Hivemind growth walls no longer reset turfs to default map tiles when destroyed V2

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -100,7 +100,10 @@
 	var/turf/T = get_turf(src)
 	switch(structure)
 		if("wall")
-			T.ChangeTurf(/turf/closed/wall/resin/regenerating)
+			if(ispath(/turf/closed/wall/resin/regenerating, /turf))
+				var/list/baseturfs = islist(T.baseturfs) ? T.baseturfs : list(T.baseturfs)
+				baseturfs |= T.type
+				T.ChangeTurf(/turf/closed/wall/resin/regenerating, baseturfs)
 		if("door")
 			new /obj/structure/mineral_door/resin(T)
 	deconstruct(TRUE)


### PR DESCRIPTION
## About The Pull Request
Теперь резиновые стены с цветокв ХМа больше не сбрасывают турф до базового тайла карты

## Why It's Good For The Game

## Changelog
:cl:
fix: HM growth walls fixed
/:cl: